### PR TITLE
feat : 프론트 요청응답시 토큰 포함 + 클래스 화면 및 스타일링

### DIFF
--- a/frontend/src/components/LikeButton.css
+++ b/frontend/src/components/LikeButton.css
@@ -1,0 +1,22 @@
+/* 좋아요 버튼 */
+.like-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 20px;
+    background-color: #ff8b94; /* 좋아요 빨간색 */
+    color: #ffffff;
+    font-size: 16px;
+    font-weight: bold;
+    border: none;
+    border-radius: 20px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    
+    height: 10px;
+    width: 300px;
+}
+
+.like-button:hover {
+    background-color: #e84141; /* hover 시 약간 어두운 빨간색 */
+}

--- a/frontend/src/components/LikeButton.js
+++ b/frontend/src/components/LikeButton.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import './LikeButton.css';
 
 const LikeButton = () => {
   const [likes, setLikes] = useState(0);
@@ -6,7 +7,7 @@ const LikeButton = () => {
   const handleLike = () => setLikes((prev) => prev + 1);
 
   return (
-    <button onClick={handleLike}>
+    <button className="like-button" onClick={handleLike}>
       좋아요 {likes}
     </button>
   );

--- a/frontend/src/components/classroom/ClassroomCard.js
+++ b/frontend/src/components/classroom/ClassroomCard.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import styles from './ClassroomCard.module.css';
 
 const ClassroomCard = ({ classroom }) => {
   const navigate = useNavigate();
 
   return (
-    <div className="classroom-card">
+    <div className={styles['classroom-card']}>
       <h3>{classroom.title}</h3>
       <p>{classroom.description}</p>
       <button onClick={() => navigate(`/classes/${classroom.id}`)}>상세보기</button>

--- a/frontend/src/components/classroom/ClassroomCard.module.css
+++ b/frontend/src/components/classroom/ClassroomCard.module.css
@@ -1,0 +1,22 @@
+/* ClassroomCard.module.css */
+.classroom-card {
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 16px;
+    text-align: center;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    cursor: pointer;
+  }
+  
+.classroom-card:hover {
+transform: translateY(-5px);
+box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.classroom-card img {
+width: 100px;
+height: 100px;
+border-radius: 50%;
+margin-bottom: 12px;
+}
+  

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -5,17 +5,25 @@ export const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false); // 로그인 여부 상태
   const [userInfo, setUserInfo] = useState({ name: '', id: '', level: '', role: '' }); // 유저 정보 상태
-  
-   // 로그인 시 호출, 유저 정보 설정
-   const login = ({name, id, level, role}) => {
+
+   // 로그인 시 호출, 유저 정보 및 토큰 설정
+   const login = ({ token, user }) => {
     setIsAuthenticated(true);
-    setUserInfo({ name, id, level, role });
+    setUserInfo(user);
+
+    // 로컬 스토리지에도 토큰과 유저 정보 저장
+    localStorage.setItem('jwtToken', token);
+    localStorage.setItem('user', JSON.stringify(user));
   };
 
   // 로그아웃 시 호출, 유저 정보 초기화
   const logout = () => {
     setIsAuthenticated(false);
     setUserInfo({ name: '', id: '', level: '', role: '' });
+
+    // 로컬 스토리지에서 토큰과 유저 정보 삭제
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
   };
 
   return (

--- a/frontend/src/pages/auth/LoginPage.js
+++ b/frontend/src/pages/auth/LoginPage.js
@@ -12,15 +12,19 @@ const LoginPage = () => {
 
   const handleLogin = async() => {
     try{
-      const response = await loginUser(userEmail, password)
-      login(); // context 를 로그인상태로 등록
+      const { token, user } = await loginUser(userEmail, password)
+
+      login({ token, user }); // context 를 로그인상태로 등록
       navigate('/'); // 로그인시 메인 페이지로 이동
     }catch(error) {
       console.log(error);
 
       //////////////임시로 로그인처리 아래 함수들 삭제해야함
       navigate('/');
-      login({name: "김동은", id: "2", level: "7", role: 'teacher'}); 
+      login({
+        token: "dummy-token", // 임시로 더미 토큰
+        user: { name: "김동은", id: "2", level: "7", role: 'teacher' }
+      }); 
     }
   };
 

--- a/frontend/src/pages/classroom/ClassInfo.js
+++ b/frontend/src/pages/classroom/ClassInfo.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const ClassInfo = ({ classroom }) => {
+  return (
+    <div className="class-info">
+      <img src={classroom.thumbnail} alt={`${classroom.title} 썸네일`} />
+      <h1>{classroom.title}</h1>
+      <p>{classroom.description}</p>
+      <p>모집 인원: {classroom.maxParticipants}명</p>
+    </div>
+  );
+};
+
+export default ClassInfo;

--- a/frontend/src/pages/classroom/ClassroomListPage.css
+++ b/frontend/src/pages/classroom/ClassroomListPage.css
@@ -1,0 +1,6 @@
+.classroom-grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    align-items: stretch;
+  }  

--- a/frontend/src/pages/classroom/ClassroomListPage.js
+++ b/frontend/src/pages/classroom/ClassroomListPage.js
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import ClassroomCard from '../../components/classroom/ClassroomCard';
 import { readClasses } from '../../services/ClassroomService.mjs';
 
+import './ClassroomListPage.css';
+
 const ClassroomList = () => {
   const [classrooms, setClassrooms] = useState([]);
 
@@ -17,7 +19,7 @@ const ClassroomList = () => {
   return (
     <div>
       <h1>클래스 목록</h1>
-      <div className="classroom-list">
+      <div className="classroom-grid">
         {classrooms.map((classroom) => (
           <ClassroomCard key={classroom.id} classroom={classroom} />
         ))}

--- a/frontend/src/pages/classroom/ClassroomPage.css
+++ b/frontend/src/pages/classroom/ClassroomPage.css
@@ -1,0 +1,99 @@
+.classroom-container {
+    display: flex;
+    flex-direction: column;
+    gap: 30px; /* 섹션 간의 간격 */
+    padding: 20px;
+    background-color: #f4f6f9; /* 부드러운 배경색 */
+    font-family: 'Arial', sans-serif;
+    min-height: 100vh; /* 화면 높이 */
+}
+
+/* 개별 섹션 스타일 */
+.section {
+    padding: 20px;
+    background-color: #ffffff; /* 흰색 배경 */
+    border-radius: 10px; /* 둥근 모서리 */
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1); /* 부드러운 그림자 */
+    transition: transform 0.3s ease, box-shadow 0.3s ease; /* 애니메이션 */
+}
+
+.section:hover {
+    transform: translateY(-5px);
+    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.15);
+}
+
+/* FAQ 섹션 */
+.faq-section {
+    padding: 15px;
+    background-color: #e8f8f5; /* 연한 녹색 배경 */
+    border-left: 5px solid #2ecc71; /* 강조를 위한 테두리 */
+}
+
+.faq-section h2 {
+    margin: 0;
+    font-size: 20px;
+    color: #27ae60;
+}
+
+/* 질문 게시판 */
+.inquiry-section {
+    padding: 15px;
+    background-color: #fef9e7; /* 연한 노란색 배경 */
+    border-left: 5px solid #f39c12;
+}
+
+.inquiry-section h2 {
+    margin: 0;
+    font-size: 20px;
+    color: #e67e22;
+}
+
+/* 게시물 섹션 */
+.post-section {
+    padding: 15px;
+    background-color: #f4ecf7; /* 연한 보라색 배경 */
+    border-left: 5px solid #9b59b6;
+}
+
+.post-section h2 {
+    margin: 0;
+    font-size: 20px;
+    color: #8e44ad;
+}
+
+/* 스케줄 섹션 */
+.schedule-section {
+    padding: 15px;
+    background-color: #ebf5fb; /* 연한 파란색 배경 */
+    border-left: 5px solid #3498db;
+}
+
+.schedule-section h2 {
+    margin: 0;
+    font-size: 20px;
+    color: #2980b9;
+}
+
+/* 수강 등록 섹션 */
+.enrollment-section {
+    padding: 15px;
+    background-color: #fdebd0; /* 연한 주황색 배경 */
+    border-left: 5px solid #e67e22;
+}
+
+.enrollment-section h2 {
+    margin: 0;
+    font-size: 20px;
+    color: #d35400;
+}
+
+/* 반응형 디자인 */
+@media screen and (max-width: 768px) {
+    .classroom-container {
+        padding: 10px;
+    }
+
+    .section {
+        padding: 15px;
+    }
+}

--- a/frontend/src/pages/classroom/ClassroomPage.js
+++ b/frontend/src/pages/classroom/ClassroomPage.js
@@ -3,27 +3,66 @@ import { useParams } from 'react-router-dom';
 
 import { readClassById } from '../../services/ClassroomService.mjs';
 import LikeButton from '../../components/LikeButton';
+import ClassInfo from './ClassInfo';
+import ClassEnrollment from './Enrollment/Enrollment';
+import ClassFAQ from './FAQ/FAQBoard';
+import ClassInquiry from './Inquiry/InquiryBoard';
+import ClassPosts from './Post/PostBoard';
+import ClassSchedule from './Schedule/ScheduleBoard';
+
+import './ClassroomPage.css'
 
 const ClassroomPage = () => {
   const { classId } = useParams();
-  const [classroom, setClassroom] = useState(null);
+  const [classroomInfo, setClassroomInfo] = useState(null);
 
   useEffect(() => {
     // API 호출로 클래스 상세 정보 가져오기
     const fetchClass = async () => {
       const data = await readClassById(classId);
-      setClassroom(data);
+      setClassroomInfo(data);
     };
     fetchClass();
   }, [classId]);
 
-  if (!classroom) return <p>로딩 중...</p>;
+  if (!classroomInfo) return <p>로딩 중...</p>;
 
   return (
-    <div>
-      <h1>{classroom.title}</h1>
-      <p>{classroom.description}</p>
-      <LikeButton />
+<div className="classroom-container">
+      {/* 클래스 정보 섹션 */}
+      <div className="section class-info-section">
+        <ClassInfo classroom={classroomInfo} />
+      </div>
+
+      {/* 수업 신청 섹션 */}
+      <div className="section enrollment-section">
+        <ClassEnrollment classId={classId}/>
+      </div>
+
+      {/* 질문 게시판 섹션 */}
+      <div className="section inquiry-section">
+        <ClassInquiry classId={classId}/>
+      </div>
+
+      {/* FAQ 섹션 */}
+      <div className="section faq-section">
+        <ClassFAQ classId={classId} />
+      </div>
+
+      {/* 스케줄 섹션 */}
+      <div className="section schedule-section">
+        <ClassSchedule classId={classId}/>
+      </div>
+
+      {/* 게시물 섹션 */}
+      <div className="section post-section">
+        <ClassPosts classId={classId}/>
+      </div>
+
+      {/* 좋아요 버튼 */}
+      <div className="section like-button">
+        <LikeButton />
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/classroom/Enrollment/Enrollment.js
+++ b/frontend/src/pages/classroom/Enrollment/Enrollment.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Enrollment = ({ classId }) => {
+  return (
+    <div className="class-registration">
+      <h2>수업 신청</h2>
+      {/* 신청 버튼과 폼 추가 */}
+    </div>
+  );
+};
+
+export default Enrollment;

--- a/frontend/src/pages/classroom/FAQ/FAQBoard.js
+++ b/frontend/src/pages/classroom/FAQ/FAQBoard.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const FAQBoard = ({ classId }) => {
+  return (
+    <div className="faq-board">
+      <h2>FAQ 게시판</h2>
+      {/* FAQ 리스트 추가 */}
+      <p>FAQ 글들이 여기에 표시됩니다.</p>
+    </div>
+  );
+};
+
+export default FAQBoard;

--- a/frontend/src/pages/classroom/Inquiry/InquiryBoard.js
+++ b/frontend/src/pages/classroom/Inquiry/InquiryBoard.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const InquiyBoard = ({ classId }) => {
+  return (
+    <div className="class-inquiry">
+      <h2>수업 문의 게시판</h2>
+      {/* 문의 리스트와 폼 추가 */}
+      <p>수업문의 글들이 여기에 표시됩니다.</p>
+    </div>
+  );
+};
+
+export default InquiyBoard;

--- a/frontend/src/pages/classroom/Post/PostBoard.js
+++ b/frontend/src/pages/classroom/Post/PostBoard.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const PostBoard = ({ classId }) => {
+  return (
+    <div className="class-posts">
+      <h2>수업 글 게시판</h2>
+      {/* 게시글 리스트 추가 */}
+      <p>수업과 관련된 글(공지,과제,자유)들이 여기에 표시됩니다.</p>
+    </div>
+  );
+};
+
+export default PostBoard;

--- a/frontend/src/pages/classroom/Schedule/ScheduleBoard.js
+++ b/frontend/src/pages/classroom/Schedule/ScheduleBoard.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const ScheduleBoard = ({ classId }) => {
+  return (
+    <div className="class-schedule">
+      <h2>클래스 스케줄러</h2>
+      {/* 일정 정보 추가 */}
+      <p>클래스 일정이 이 달력에 표시됩니다.</p>
+    </div>
+  );
+};
+
+export default ScheduleBoard;

--- a/frontend/src/services/AuthService.mjs
+++ b/frontend/src/services/AuthService.mjs
@@ -1,10 +1,4 @@
-import axios from 'axios';
-
-const apiClient = axios.create({
-    baseURL: 'http://localhost:8080', // 기본 URL 설정
-    timeout: 5000,                     // 요청 제한 시간 설정
-    headers: { 'Content-Type': 'application/json' }
-  });
+import apiClient from './apiClient.mjs';
 
 /**
  * 로그인
@@ -16,14 +10,19 @@ export const loginUser = async (username, password) => {
         username,
         password,
       });
-      console.log("로그인 API 성공:", response)
-      return response.data;
-    }catch(error){
+    
+      // 서버에서 받은 JWT 토큰과 유저 정보 반환
+      const { token, user } = response.data;  // 서버에서 반환된 데이터 구조에 맞게 수정 필요
+      return { token, user };  // 토큰과 유저 정보를 객체로 반환
+  }catch(error){
       console.log("로그인 API 실패",error);
-        
-      // 로그인실패시 임시로 더미 데이터 반환
-      const dummyData = { id: 1, name: '최예원', role: 'student', level: '3' }
-  
+      
+      // 로그인 실패 시 임시 더미 데이터 반환
+      const dummyData = { 
+        token: "dummy-token", // 더미 토큰
+        user: { id: 1, name: '최예원', role: 'student', level: '3' } // 더미 유저 정보
+      };
+
       return dummyData;
     }
 };

--- a/frontend/src/services/ClassroomService.mjs
+++ b/frontend/src/services/ClassroomService.mjs
@@ -27,8 +27,8 @@ export const readClasses = async () => {
   } catch (error) {
     console.error('클래스 목록 조회 API 실패:', error);
     return [
-      { id: 'dummy-1', title: '더미 클래스 1', description: 'API 실패로 생성된 더미 데이터 1' },
-      { id: 'dummy-2', title: '더미 클래스 2', description: 'API 실패로 생성된 더미 데이터 2' },
+      { id: 'dummy-1', title: '한석원의 60일 지옥 부트캠프', description: '하루 18시간 공부할 학생들만 참여가능' },
+      { id: 'dummy-2', title: '현우진의 노베이스 부트캠프', description: '인생 조진거같다 싶으면 드루와 갱생시켜줌' },
     ]; // 더미 데이터 반환
   }
 };
@@ -46,8 +46,9 @@ export const readClassById = async (classId) => {
     console.error('클래스 상세 조회 API 실패:', error);
     return {
       id: classId,
-      title: `더미 클래스 제목 (${classId})`,
-      description: 'API 실패로 생성된 더미 데이터 상세 정보',
+      title: `한석원의 60일 지옥의 수학 부트캠프`,
+      description: '9등급도 60일만에 1등급을 만들어주는 수업',
+      thumbnail: 'temp'
     }; // 더미 데이터 반환
   }
 };

--- a/frontend/src/services/ClassroomService.mjs
+++ b/frontend/src/services/ClassroomService.mjs
@@ -1,10 +1,4 @@
-import axios from 'axios';
-
-const apiClient = axios.create({
-  baseURL: 'http://localhost:8080', // 기본 URL 설정
-  timeout: 5000,                   // 요청 제한 시간 설정
-  headers: { 'Content-Type': 'application/json' },
-});
+import apiClient from './apiClient.mjs';
 
 /**
  * 클래스 생성

--- a/frontend/src/services/MyPageService.mjs
+++ b/frontend/src/services/MyPageService.mjs
@@ -1,10 +1,4 @@
-import axios from 'axios';
-
-const apiClient = axios.create({
-    baseURL: 'http://localhost:8080', // 기본 URL 설정
-    timeout: 5000,                     // 요청 제한 시간 설정
-    headers: { 'Content-Type': 'application/json' }
-  });
+import apiClient from './apiClient.mjs';
 
 /**
  * 자기소개 조회

--- a/frontend/src/services/OfficialProfileService.mjs
+++ b/frontend/src/services/OfficialProfileService.mjs
@@ -1,10 +1,4 @@
-import axios from 'axios';
-
-const apiClient = axios.create({
-    baseURL: 'http://localhost:8080', // 기본 URL 설정
-    timeout: 5000,                     // 요청 제한 시간 설정
-    headers: { 'Content-Type': 'application/json' }
-  });
+import apiClient from './apiClient.mjs';
 
 /**
  * 공식프로필 조회

--- a/frontend/src/services/UserService.mjs
+++ b/frontend/src/services/UserService.mjs
@@ -1,10 +1,4 @@
-import axios from 'axios';
-
-const apiClient = axios.create({
-    baseURL: 'http://localhost:8080', // 기본 URL 설정
-    timeout: 5000,                     // 요청 제한 시간 설정
-    headers: { 'Content-Type': 'application/json' }
-  });
+import apiClient from './apiClient.mjs';
 
 /**
  * 더미데이터 생성
@@ -24,7 +18,7 @@ export const makeDummyUser = async () => {
 export const signUpUser = async (email) => {
   console.log("회원가입 API 시도:", email)
   try{
-    const response = await apiClient.post('/api/users/sign-up', {
+    const response = await apiClient.post('/users/sign-up', {
       email
     });
     console.log("회원가입 API 성공:", response)
@@ -70,7 +64,7 @@ export const readUser = async (userId) => {
 export const readUsers = async (pathname) => {
     console.log("회원목록조회 API 시도:", pathname)
     try {
-      const response = await apiClient.get('/api/users');
+      const response = await apiClient.get('/users');
 
       console.log("회원목록조회 API 성공:", response)
       return response.data;
@@ -99,7 +93,7 @@ export const readUsers = async (pathname) => {
 export const updateUser = async (accountData) => {
     console.error('회원수정 API 시도:', accountData);
     try{
-      const response = await apiClient.post('/api/users/{userId}', {
+      const response = await apiClient.post('/api/users/update/{userId}', {
         accountData
       });
       console.error('회원수정 API 성공:', response);

--- a/frontend/src/services/apiClient.mjs
+++ b/frontend/src/services/apiClient.mjs
@@ -1,0 +1,35 @@
+// apiClient.js
+
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: 'http://localhost:8080', // 기본 URL 설정
+  timeout: 5000,                    // 요청 제한 시간 설정
+  headers: { 'Content-Type': 'application/json' } // 기본 헤더 설정
+});
+
+/**
+ * 서버에 요청시 토큰이 있으면 헤더에 삽입하여 보냄
+ */
+apiClient.interceptors.request.use((req) => {
+    const token = localStorage.getItem('jwtToken'); // localStorage에서 토큰 가져오기
+    if (token) {
+      req.headers['Authorization'] = `Bearer ${token}`; // 토큰을 헤더에 추가
+    }
+
+    // 디버깅
+    console.log("Request Headers:", req.headers);
+    return req;
+  }, (error) => {
+    return Promise.reject(error);
+  });
+  
+/**
+ * 서버에서의 응답 헤더에 토큰이 포함되어있는지 검사
+ */
+apiClient.interceptors.response.use(res => {
+    console.log("Response Headers:", res.headers);
+    return res;
+  });
+
+export default apiClient;


### PR DESCRIPTION
### 연관된 이슈

> ex) #37

### 작업 내용

> 로그인시 서버로 부터 JWT 토큰을 Body 로 받고, 이를 LocalStorage 에 저장해둔 후, 서버 요청시 헤더에 전송하도록 만들었습니다. (interceptor 이용)
> 그 과정에서 axios 관련 설정 파일을 따로 분리하여 각 api 요청 service 에 대한 js 에서 사용하도록 정리하였습니다

> 클래스 목록조회와 상세조회 화면을 완료했습니다 (생성, 수정 및 스타일링 리팩토링 예정)

![image](https://github.com/user-attachments/assets/960e008c-e15b-403e-a157-38a8eb7c6c3b)
![image](https://github.com/user-attachments/assets/364b7408-f195-47c6-869d-6ccfc3ecfacd)

아직 많이 짜치므로 느낌만 전달

### 리뷰 요구사항

> 중점적으로 리뷰해야 하는 포인트를 짚어주세요.
