### PR TITLE
Hot fix/member jpa

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -25,13 +25,22 @@ CREATE TABLE IF NOT EXISTS member (
     role ENUM('ROLE_GUEST', 'ROLE_STUDENT', 'ROLE_TEACHER', 'ROLE_PARENTS', 'ROLE_ADMIN') NOT NULL,  -- 수정된 부분
     from_social TINYINT DEFAULT 0,
     init TINYINT DEFAULT 1,
-    deleted TINYINT DEFAULT 0
-    );
+    deleted TINYINT DEFAULT 0,
+    mod_date datetime(6),
+    reg_date datetime(6),
+    dtype varchar(31) NOT NULL,
+    created_by varchar(255),
+    del_date datetime(6),
+    deleted_by varchar(255),
+    modified_by varchar(255),
+    introduction varchar(255) default '안녕하세요. 잘 부탁드립니다.',
+    image_data longblob
+);
 
 -- 멤버 데이터 삽입
-INSERT INTO member (user_id, password, name, phone_address, email, sex, referral_id, level, role, from_social, init, deleted)
+INSERT INTO member (user_id, password, name, phone_address, email, sex, referral_id, level, role, from_social, init, deleted, reg_date, dtype)
 VALUES
-    (UUID(), '$2a$10$J03L0oKiIDC5mhdYxzOTresMpd9gMfqbJakKr.iHAsgUbq/To2VZO', '관리자', '010-1234-1234', 'admin@gmail.com', 'MALE', null, 1, 'ROLE_ADMIN', 0, 1, 0),
-    (UUID(), '$2a$10$/essrJvIRI8sf52JKG/YHO.5bv6JOqmk8UFD.kFK8a12WtQZ.t2sK', '학생', '010-1234-1234', 'student@gmail.com', 'MALE', null, 1, 'ROLE_STUDENT', 0, 1, 0),
-    (UUID(), '$2a$10$J03L0oKiIDC5mhdYxzOTresMpd9gMfqbJakKr.iHAsgUbq/To2VZO', '강사', '010-1234-1234', 'teacher@gmail.com', 'MALE', null, 1, 'ROLE_TEACHER', 0, 1, 0),
-    (UUID(), '$2a$10$tPBgYrrCy8kKo7G.w5uVJeCcGPaCDOC80oV5qK2PE68THsjk443wy', '학부모', '010-1234-1234', 'parents@gmail.com', 'FEMALE', null, 1, 'ROLE_PARENTS', 0, 1, 0);
+    (UUID(), '$2a$10$J03L0oKiIDC5mhdYxzOTresMpd9gMfqbJakKr.iHAsgUbq/To2VZO', '관리자', '010-1234-1234', 'admin@gmail.com', 'MALE', null, 1, 'ROLE_ADMIN', 0, 1, 0, NOW(), 'A'),
+    (UUID(), '$2a$10$/essrJvIRI8sf52JKG/YHO.5bv6JOqmk8UFD.kFK8a12WtQZ.t2sK', '학생', '010-1234-1234', 'student@gmail.com', 'MALE', null, 1, 'ROLE_STUDENT', 0, 1, 0, NOW(), 'S'),
+    (UUID(), '$2a$10$J03L0oKiIDC5mhdYxzOTresMpd9gMfqbJakKr.iHAsgUbq/To2VZO', '강사', '010-1234-1234', 'teacher@gmail.com', 'MALE', null, 1, 'ROLE_TEACHER', 0, 1, 0, NOW(), 'T'),
+    (UUID(), '$2a$10$tPBgYrrCy8kKo7G.w5uVJeCcGPaCDOC80oV5qK2PE68THsjk443wy', '학부모', '010-1234-1234', 'parents@gmail.com', 'FEMALE', null, 1, 'ROLE_PARENTS', 0, 1, 0, NOW(), 'P');

--- a/src/main/generated/com/idealstudy/mvp/mapstruct/MemberMapperImpl.java
+++ b/src/main/generated/com/idealstudy/mvp/mapstruct/MemberMapperImpl.java
@@ -1,0 +1,147 @@
+package com.idealstudy.mvp.mapstruct;
+
+import com.idealstudy.mvp.application.dto.PageResultDto;
+import com.idealstudy.mvp.application.dto.member.MemberDto;
+import com.idealstudy.mvp.application.dto.member.MemberPageResultDto;
+import com.idealstudy.mvp.infrastructure.jpa.entity.member.MemberEntity;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import org.springframework.stereotype.Component;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2024-11-28T20:02:59+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21 (Oracle Corporation)"
+)
+@Component
+public class MemberMapperImpl implements MemberMapper {
+
+    @Override
+    public MemberDto entityToDto(MemberEntity entity) {
+        if ( entity == null ) {
+            return null;
+        }
+
+        MemberDto.MemberDtoBuilder memberDto = MemberDto.builder();
+
+        memberDto.userId( entity.getUserId() );
+        memberDto.password( entity.getPassword() );
+        memberDto.name( entity.getName() );
+        memberDto.phoneAddress( entity.getPhoneAddress() );
+        memberDto.email( entity.getEmail() );
+        memberDto.sex( entity.getSex() );
+        memberDto.referralId( entity.getReferralId() );
+        memberDto.level( entity.getLevel() );
+        memberDto.role( entity.getRole() );
+        memberDto.introduction( entity.getIntroduction() );
+        byte[] profile = entity.getProfile();
+        if ( profile != null ) {
+            memberDto.profile( Arrays.copyOf( profile, profile.length ) );
+        }
+        memberDto.fromSocial( entity.getFromSocial() );
+        memberDto.init( entity.getInit() );
+        memberDto.deleted( entity.getDeleted() );
+
+        return memberDto.build();
+    }
+
+    @Override
+    public MemberEntity dtoToEntity(MemberDto dto) {
+        if ( dto == null ) {
+            return null;
+        }
+
+        MemberEntity.MemberEntityBuilder memberEntity = MemberEntity.builder();
+
+        memberEntity.userId( dto.getUserId() );
+        memberEntity.password( dto.getPassword() );
+        memberEntity.name( dto.getName() );
+        memberEntity.phoneAddress( dto.getPhoneAddress() );
+        memberEntity.email( dto.getEmail() );
+        memberEntity.sex( dto.getSex() );
+        memberEntity.referralId( dto.getReferralId() );
+        memberEntity.level( dto.getLevel() );
+        memberEntity.role( dto.getRole() );
+        memberEntity.introduction( dto.getIntroduction() );
+        byte[] profile = dto.getProfile();
+        if ( profile != null ) {
+            memberEntity.profile( Arrays.copyOf( profile, profile.length ) );
+        }
+        memberEntity.fromSocial( dto.getFromSocial() );
+        memberEntity.init( dto.getInit() );
+        memberEntity.deleted( dto.getDeleted() );
+
+        return memberEntity.build();
+    }
+
+    @Override
+    public void updateEntityFromDto(MemberDto dto, MemberEntity entity) {
+        if ( dto == null ) {
+            return;
+        }
+
+        if ( dto.getPassword() != null ) {
+            entity.setPassword( dto.getPassword() );
+        }
+        if ( dto.getName() != null ) {
+            entity.setName( dto.getName() );
+        }
+        if ( dto.getPhoneAddress() != null ) {
+            entity.setPhoneAddress( dto.getPhoneAddress() );
+        }
+        if ( dto.getEmail() != null ) {
+            entity.setEmail( dto.getEmail() );
+        }
+        if ( dto.getSex() != null ) {
+            entity.setSex( dto.getSex() );
+        }
+        if ( dto.getReferralId() != null ) {
+            entity.setReferralId( dto.getReferralId() );
+        }
+        if ( dto.getLevel() != null ) {
+            entity.setLevel( dto.getLevel() );
+        }
+        if ( dto.getRole() != null ) {
+            entity.setRole( dto.getRole() );
+        }
+        if ( dto.getIntroduction() != null ) {
+            entity.setIntroduction( dto.getIntroduction() );
+        }
+        byte[] profile = dto.getProfile();
+        if ( profile != null ) {
+            entity.setProfile( Arrays.copyOf( profile, profile.length ) );
+        }
+        entity.setFromSocial( dto.getFromSocial() );
+        entity.setInit( dto.getInit() );
+        entity.setDeleted( dto.getDeleted() );
+    }
+
+    @Override
+    public MemberPageResultDto toApplicationPageResult(PageResultDto<MemberDto, MemberEntity> pageResultDto) {
+        if ( pageResultDto == null ) {
+            return null;
+        }
+
+        MemberPageResultDto memberPageResultDto = new MemberPageResultDto();
+
+        List<MemberDto> list = pageResultDto.getDtoList();
+        if ( list != null ) {
+            memberPageResultDto.setDtoList( new ArrayList<MemberDto>( list ) );
+        }
+        memberPageResultDto.setTotalPage( pageResultDto.getTotalPage() );
+        memberPageResultDto.setPage( pageResultDto.getPage() );
+        memberPageResultDto.setSize( pageResultDto.getSize() );
+        memberPageResultDto.setStartPage( pageResultDto.getStartPage() );
+        memberPageResultDto.setEndPage( pageResultDto.getEndPage() );
+        memberPageResultDto.setHasPrev( pageResultDto.isHasPrev() );
+        memberPageResultDto.setHasNext( pageResultDto.isHasNext() );
+        List<Integer> list1 = pageResultDto.getPageList();
+        if ( list1 != null ) {
+            memberPageResultDto.setPageList( new ArrayList<Integer>( list1 ) );
+        }
+
+        return memberPageResultDto;
+    }
+}

--- a/src/main/java/com/idealstudy/mvp/application/dto/member/AdminDto.java
+++ b/src/main/java/com/idealstudy/mvp/application/dto/member/AdminDto.java
@@ -1,0 +1,19 @@
+package com.idealstudy.mvp.application.dto.member;
+
+import com.idealstudy.mvp.enums.member.Gender;
+import com.idealstudy.mvp.enums.member.Role;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminDto extends MemberDto{
+
+    public AdminDto(String userId, String password, String name, String phoneAddress, String email, Gender sex,
+              byte[] profile, int fromSocial) {
+        super(userId, password, name, phoneAddress, email, sex, "", 9999, Role.ROLE_ADMIN,
+                "admin", profile, fromSocial, 0, 0);
+    }
+
+}

--- a/src/main/java/com/idealstudy/mvp/application/dto/member/MemberDto.java
+++ b/src/main/java/com/idealstudy/mvp/application/dto/member/MemberDto.java
@@ -25,6 +25,10 @@ public class MemberDto {
 
     private Role role;
 
+    private String introduction;
+
+    private byte[] profile;
+
     private int fromSocial;
 
     private int init;

--- a/src/main/java/com/idealstudy/mvp/application/dto/member/ParentDto.java
+++ b/src/main/java/com/idealstudy/mvp/application/dto/member/ParentDto.java
@@ -1,0 +1,18 @@
+package com.idealstudy.mvp.application.dto.member;
+
+import com.idealstudy.mvp.enums.member.Gender;
+import com.idealstudy.mvp.enums.member.Role;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ParentDto extends MemberDto{
+    ParentDto(String userId, String password, String name, String phoneAddress, String email, Gender sex,
+              String referralId, Integer level, String introduction, byte[] profile, int fromSocial,
+              int init, int deleted) {
+        super(userId, password, name, phoneAddress, email, sex, referralId, level, Role.ROLE_PARENTS,
+                introduction, profile,  fromSocial, init, deleted);
+    }
+}

--- a/src/main/java/com/idealstudy/mvp/application/dto/member/StudentDto.java
+++ b/src/main/java/com/idealstudy/mvp/application/dto/member/StudentDto.java
@@ -1,0 +1,21 @@
+package com.idealstudy.mvp.application.dto.member;
+
+
+import com.idealstudy.mvp.enums.member.Gender;
+import com.idealstudy.mvp.enums.member.Role;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StudentDto extends MemberDto{
+    StudentDto(String userId, String password, String name, String phoneAddress, String email, Gender sex,
+               String referralId, Integer level, String introduction, byte[] profile, int fromSocial,
+               int init, int deleted) {
+        super(userId, password, name, phoneAddress, email, sex, referralId, level, Role.ROLE_STUDENT,
+                introduction, profile, fromSocial, init, deleted);
+    }
+
+
+}

--- a/src/main/java/com/idealstudy/mvp/application/dto/member/TeacherDto.java
+++ b/src/main/java/com/idealstudy/mvp/application/dto/member/TeacherDto.java
@@ -1,0 +1,19 @@
+package com.idealstudy.mvp.application.dto.member;
+
+
+import com.idealstudy.mvp.enums.member.Gender;
+import com.idealstudy.mvp.enums.member.Role;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TeacherDto extends MemberDto{
+    TeacherDto(String userId, String password, String name, String phoneAddress, String email, Gender sex,
+               String referralId, Integer level, String introduction, byte[] profile, int fromSocial,
+               int init, int deleted) {
+        super(userId, password, name, phoneAddress, email, sex, referralId, level, Role.ROLE_TEACHER, introduction,
+                profile,  fromSocial, init, deleted);
+    }
+}

--- a/src/main/java/com/idealstudy/mvp/infrastructure/OfficialProfileRepository.java
+++ b/src/main/java/com/idealstudy/mvp/infrastructure/OfficialProfileRepository.java
@@ -5,7 +5,9 @@ import com.idealstudy.mvp.application.dto.OfficialProfileDto;
 
 public interface OfficialProfileRepository {
 
-    void create();
+    void create(String teacherId);
 
-    OfficialProfileDto findById(Long id);
+    OfficialProfileDto findByTeacherId(String teacherId);
+
+    void update(String teacherId, String contents);
 }

--- a/src/main/java/com/idealstudy/mvp/infrastructure/impl/OfficialProfileRepositoryImpl.java
+++ b/src/main/java/com/idealstudy/mvp/infrastructure/impl/OfficialProfileRepositoryImpl.java
@@ -16,11 +16,21 @@ public class OfficialProfileRepositoryImpl implements OfficialProfileRepository 
     private final OfficialProfileJpaRepository officialProfileJpaRepository;
 
     @Override
-    public void create() {
+    public void create(String teacherId) {
 
     }
 
     @Override
+    public OfficialProfileDto findByTeacherId(String teacherId) {
+        return null;
+    }
+
+    @Override
+    public void update(String teacherId, String contents) {
+
+    }
+
+    // @Override
     public OfficialProfileDto findById(Long id) {
         OfficialProfileEntity entity = officialProfileJpaRepository.findById(id).orElseThrow();
         return entity.toDto();

--- a/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/OfficialProfileEntity.java
+++ b/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/OfficialProfileEntity.java
@@ -26,7 +26,7 @@ public class OfficialProfileEntity {
     // 프로필 - 강사 일대일 단방향 연관관계
     // 단방향 매핑으로 성능 최적화
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "teacher_id")
+    @JoinColumn(name = "USER_ID")  // MEMBER의 PK를 관리할 FK로 지목
     private TeacherEntity teacher;
 
     public OfficialProfileDto toDto() {

--- a/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/AdminEntity.java
+++ b/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/AdminEntity.java
@@ -1,0 +1,15 @@
+package com.idealstudy.mvp.infrastructure.jpa.entity.member;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Data
+@Entity(name = "Admin")
+@Table(name = "ADMIN")
+@DiscriminatorValue("A")
+public class AdminEntity extends MemberEntity{
+
+    // nothing
+}

--- a/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/MemberEntity.java
+++ b/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/MemberEntity.java
@@ -5,7 +5,8 @@ import com.idealstudy.mvp.infrastructure.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Entity
+@Entity(name = "Member")
+@Table(name = "MEMBER")
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name="DTYPE") // 부모클래스 구분 칼럼
 @Getter
@@ -54,6 +55,16 @@ public class MemberEntity extends BaseEntity {
         roleSet.add(role);
     }
      */
+
+    @Column(columnDefinition = "varchar(255) default '안녕하세요. 잘 부탁드립니다.'")
+    private String introduction;
+
+    // Specifies that a persistent property or field should be persisted as a large object
+    // to a database-supported large object type.
+    @Lob @Basic(fetch=FetchType.LAZY)
+    // LONGBLOB: MySQL에서 대용량 바이너리 데이터를 저장하기 위한 데이터 타입을 지정
+    @Column(name = "image_data", columnDefinition="LONGBLOB")
+    private byte[] profile;
 
     @Column(columnDefinition = "TINYINT")
     private int fromSocial;

--- a/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/ParentsEntity.java
+++ b/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/ParentsEntity.java
@@ -1,0 +1,15 @@
+package com.idealstudy.mvp.infrastructure.jpa.entity.member;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Data
+@Entity(name = "Parents")
+@Table(name = "PARENTS")
+@DiscriminatorValue("P")
+public class ParentsEntity extends MemberEntity {
+
+    // nothing
+}

--- a/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/StudentEntity.java
+++ b/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/StudentEntity.java
@@ -1,19 +1,17 @@
 package com.idealstudy.mvp.infrastructure.jpa.entity.member;
 
 import com.idealstudy.mvp.infrastructure.jpa.entity.classroom.ClassroomEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
 import java.util.List;
+
+import jakarta.persistence.Table;
 import lombok.Data;
 
 @Data
-@Entity
+@Entity(name = "Student")
+@Table(name = "STUDENT")
 @DiscriminatorValue("S")
 public class StudentEntity extends MemberEntity {
 

--- a/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/TeacherEntity.java
+++ b/src/main/java/com/idealstudy/mvp/infrastructure/jpa/entity/member/TeacherEntity.java
@@ -1,20 +1,17 @@
 package com.idealstudy.mvp.infrastructure.jpa.entity.member;
 
 import com.idealstudy.mvp.infrastructure.jpa.entity.classroom.ClassroomEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import java.util.List;
+
+import jakarta.persistence.Table;
 import lombok.Data;
 
 @Data
-@Entity
+@Entity(name = "Teacher")
+@Table(name = "TEACHER")
 @DiscriminatorValue("T")
 public class TeacherEntity extends MemberEntity {
 

--- a/src/main/java/com/idealstudy/mvp/infrastructure/jpa/repository/member/MemberJpaRepository.java
+++ b/src/main/java/com/idealstudy/mvp/infrastructure/jpa/repository/member/MemberJpaRepository.java
@@ -2,8 +2,10 @@ package com.idealstudy.mvp.infrastructure.jpa.repository.member;
 
 import com.idealstudy.mvp.infrastructure.jpa.entity.member.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberJpaRepository extends JpaRepository<MemberEntity, String> {
 
+    @Query(value = "SELECT m FROM Member m WHERE m.email = :email")
     MemberEntity findByEmail(String email);
 }

--- a/src/main/java/com/idealstudy/mvp/presentation/controller/member/MemberController.java
+++ b/src/main/java/com/idealstudy/mvp/presentation/controller/member/MemberController.java
@@ -69,7 +69,11 @@ public class MemberController {
             // TODO: 다른 권한에 대해서도 회원가입이 가능하도록 해야 함.
             password = memberService.addMember(email, token, Role.ROLE_STUDENT);
 
-            officialProfileService.create();
+            // 마이페이지 자동 생성
+
+            // (강사에 한해서) 공식 페이지 자동 생성
+            if(true)
+                officialProfileService.create();
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
             return new ResponseEntity<String>(e.getMessage(), HttpStatusCode.valueOf(400));

--- a/src/test/java/com/idealstudy/mvp/infrastructure/MemberRepositoryTest.java
+++ b/src/test/java/com/idealstudy/mvp/infrastructure/MemberRepositoryTest.java
@@ -4,6 +4,7 @@ import com.idealstudy.mvp.application.dto.PageRequestDto;
 import com.idealstudy.mvp.application.dto.member.MemberDto;
 import com.idealstudy.mvp.enums.member.Gender;
 import com.idealstudy.mvp.enums.member.Role;
+import com.idealstudy.mvp.infrastructure.jpa.entity.member.MemberEntity;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ public class MemberRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Deprecated
     @Test
     @DisplayName("더미 데이터 삽입")
     public void setup() {
@@ -82,13 +84,55 @@ public class MemberRepositoryTest {
     */
 
     @Test
-    @DisplayName("이메일 조회 테스트")
-    public void testEmail() {
+    @DisplayName("관리자 조회 테스트")
+    public void testAdminEmail() {
 
-        String input = "tester1@gmail.com";
+        String input = "admin@gmail.com";
 
-        Assertions.assertThat(memberRepository.findByEmail(input))
+        MemberDto dto = memberRepository.findByEmail(input);
+        Assertions.assertThat(dto)
                 .isNotNull();
+        Assertions.assertThat(dto.getRole()).isEqualTo(Role.ROLE_ADMIN);
+
+    }
+
+    @Test
+    @DisplayName("학생 조회 테스트")
+    public void testStudentEmail() {
+
+        String input = "student@gmail.com";
+
+        MemberDto dto = memberRepository.findByEmail(input);
+        Assertions.assertThat(dto)
+                .isNotNull();
+        Assertions.assertThat(dto.getRole()).isEqualTo(Role.ROLE_STUDENT);
+
+    }
+
+    @Test
+    @DisplayName("강사 조회 테스트")
+    public void testTeacherEmail() {
+
+        String input = "teacher@gmail.com";
+
+        MemberDto dto = memberRepository.findByEmail(input);
+        Assertions.assertThat(dto)
+                .isNotNull();
+        Assertions.assertThat(dto.getRole()).isEqualTo(Role.ROLE_TEACHER);
+
+    }
+
+    @Test
+    @DisplayName("학부모 조회 테스트")
+    public void testParentsEmail() {
+
+        String input = "parents@gmail.com";
+
+        MemberDto dto = memberRepository.findByEmail(input);
+        Assertions.assertThat(dto)
+                .isNotNull();
+        Assertions.assertThat(dto.getRole()).isEqualTo(Role.ROLE_PARENTS);
+
     }
 
     @Test
@@ -99,6 +143,20 @@ public class MemberRepositoryTest {
 
         Assertions.assertThatThrownBy(() -> memberRepository.findByEmail(input))
                 .isInstanceOf(NullPointerException.class);
+    }
+    
+    @Test
+    @DisplayName("프로필 이미지 입력 테스트")
+    public void testImage() {
+
+        /*
+        MemberDto memberDto = MemberDto.builder()
+                .
+                        .build();
+
+        memberRepository.create();
+         */
+
     }
 
     @Test


### PR DESCRIPTION
### 연관된 이슈

> ex) #1 

### 작업 내용

> 이번 PR에서 작업한 내용을 간단히 서술해주세요.

ERD 재설계에 따라 엔티티 간 상속관계를 구현하면서, 기존 상위 엔티티에서는 추가적으로 DiscriminatorValue(default: DTYPE)를 관리해야 한다. 하지만 이전 버전의 엔티티는 이를 관리하는 능력이 없었고, 그에 따라 최신 버전에서 JPA가 Discriminator value를 찾지 못해 오류를 무한히 반환하였다.

이를 해결하기 위해 기존 테이블 구조에서 DiscriminatorValue를 관리하기 위한 DTYPE(DiscriminatorColumn에 정의한 이름) column을 추가하였으며, 더미 데이터에도 각 자식 엔티티에 정의된 DiscriminatorValue에 해당하는 값들을 넣어주었다.

다만 그냥 상위 엔티티를 사용하여 JPA 연산을 수행하려고 하면, JPA는 계속 특정 자식 엔티티로 판별하기 위해 자동으로 DTYPE을 찾으려고 애쓴다. 하지만 단순 조회 시에는 상위 엔티티에 저장되어 있는 정보(여기에 ID, 이름, 비밀번호, email 등 개인 식별을 위한 정보가 다 들어 있음)만으로도 충분히 식별이 가능하기 때문에, ~~순수하게 상위 엔티티 객체가 모방한 테이블 정보를 가져오기 위해 단순한 JPQL 쿼리문을 직접 작성함으로써 DTYPE을 무시하고 상위 엔티티만으로 통신할 수 있도록 구현함.~~ 지금 확인해보니, 항상 상위 엔티티를 기준으로 각 자식 엔티티들의 LEFT JOIN 조건과 일치하는 것에 대해 전부 조회하는 쿼리문(모든 자식 엔티티에 대해 각각 LEFT JOIN문을 생성함)을 내부적으로 생성하는 것을 확인했다. 그럼에도 불구하고, 이러한 로직은 JPQL을 사용했을 때 자연스럽게 동작하는 방식이기 때문에, 상위 엔티티로 조회하려는 경우 JPQL은 꼭 써줘야 한다. 

### 리뷰 요구사항

> 중점적으로 리뷰해야 하는 포인트를 짚어주세요.
