### PR TITLE
refactor : 상태관리 리팩토링 contextAPI to Zustand

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,11 +1,11 @@
-import React, { useContext } from "react";
+import React, { useEffect } from "react";
 import {
   BrowserRouter as Router,
   Route,
   Routes,
   useLocation,
 } from "react-router-dom";
-import { AuthProvider, AuthContext } from "./context/AuthContext";
+import useAuthStore from "./stores/authStore";
 import HomePage from "./pages/home/HomePage";
 import SignUpPage from "./pages/auth/SignUpPage";
 import SignUpCompletePage from "./pages/auth/SignUpCompletePage";
@@ -46,19 +46,22 @@ import EnrollmentBoardPage from "./pages/classroom/preClass/enrollment/Enrollmen
 
 const App = () => {
   return (
-    <AuthProvider>
-      <Router>
-        <AppContent />
-      </Router>
-    </AuthProvider>
+    <Router>
+      <AppContent />
+    </Router>
   );
 };
 
 const AppContent = () => {
-  const { logout, isAuthenticated, userInfo } = useContext(AuthContext);
+  const { logout, isAuthenticated, userInfo, initialize } = useAuthStore();
   const location = useLocation();
-  // 현재 경로 prefix
   const here = location.pathname.split("/")[1];
+
+  // 앱 시작시 인증 상태 초기화
+  useEffect(() => {
+    console.log("[debug]: initialize");
+    initialize();
+  }, [initialize]);
 
   return (
     <>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -78,7 +78,7 @@ const AppContent = () => {
             <Route path="/teacherRoom">
               <Route
                 path="classes"
-                element={<TeacherClassroomListPage userInfo={userInfo} />}
+                element={<TeacherClassroomListPage />}
               />
               <Route path="students" element={<StudentListPage />} />
               <Route path="assignments" element={<AssignmentListPage />} />
@@ -99,7 +99,7 @@ const AppContent = () => {
               <Route path="classes" element={<StudentClassroomListPage />} />
               <Route
                 path="enrollments"
-                element={<EnrollmentBoardPage userInfo={userInfo} />}
+                element={<EnrollmentBoardPage  />}
               />
               <Route
                 path="assignments"
@@ -135,7 +135,7 @@ const AppContent = () => {
             <Route path="/students" element={<ProfileListPage />} />
             <Route
               path="/myPage/:id"
-              element={<ProfilePage userInfo={userInfo} />}
+              element={<ProfilePage />}
             />
             {/* user - teachers only */}
             <Route
@@ -161,7 +161,7 @@ const AppContent = () => {
             {/* 클래스 상세 */}
             <Route
               path="/classes/:classId"
-              element={<ClassroomDetailPage userInfo={userInfo} />}
+              element={<ClassroomDetailPage />}
             />
 
             {/* classroom - inquiry */}

--- a/frontend/src/components/classroom/preClass/enrollment/Enrollment.js
+++ b/frontend/src/components/classroom/preClass/enrollment/Enrollment.js
@@ -1,12 +1,12 @@
-import React, { useState, useContext } from "react";
+import React, { useState } from "react";
 import EnrollmentForm from "./EnrollmentForm";
 import enrollmentFormModalcss from "./EnrollmentFormModalcss";
-import { AuthContext } from "../../../../context/AuthContext";
+import useAuthStore from "../../../../stores/authStore";
 import Modal from "react-modal";
 
 const Enrollment = ({ classId }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { userInfo } = useContext(AuthContext);
+  const userInfo = useAuthStore((state) => state.userInfo);
 
   // 모달 열기
   const openModal = () => {

--- a/frontend/src/components/classroom/preClass/enrollment/EnrollmentList.js
+++ b/frontend/src/components/classroom/preClass/enrollment/EnrollmentList.js
@@ -3,10 +3,12 @@ import {
   readEnrollmentsByStudentId,
   readEnrollmentsByStudentJWT,
 } from "../../../../services/classroom/EnrollmentService.mjs";
+import useAuthStore from "../../../../stores/authStore";
 
-const EnrollmentList = ({ userInfo }) => {
+const EnrollmentList = () => {
   const [enrollments, setEnrollments] = useState([]);
   const [enrollmentsParent, setEnrollmentsParent] = useState([]);
+  const userInfo = useAuthStore((state) => state.userInfo);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/frontend/src/components/classroom/preClass/inquiry/InquiryContent.js
+++ b/frontend/src/components/classroom/preClass/inquiry/InquiryContent.js
@@ -1,10 +1,10 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+import useAuthStore from "../../../../stores/authStore";
 import {
   deleteInquiry,
   readInquiry,
 } from "../../../../services/classroom/InquiryService.mjs";
 import { useNavigate, useParams } from "react-router-dom";
-import { AuthContext } from "../../../../context/AuthContext";
 import Button from "../../../../components/Button.js";
 
 // 문의 상세정보 및 수정삭제
@@ -12,7 +12,7 @@ const InquiryContent = () => {
   const { inquiryId, classId } = useParams();
   const [inquiries, setInquiries] = useState([]);
   const navigate = useNavigate();
-  const { userInfo } = useContext(AuthContext);
+  const userInfo = useAuthStore((state) => state.userInfo);
 
   useEffect(() => {
     const fetchInquiry = async () => {

--- a/frontend/src/pages/auth/LoginPage.js
+++ b/frontend/src/pages/auth/LoginPage.js
@@ -1,11 +1,11 @@
-import React, { useContext, useState } from "react";
-import { AuthContext } from "../../context/AuthContext";
+import React, { useState } from "react";
+import useAuthStore from "../../stores/authStore";  // zustand store import
 import { useNavigate } from "react-router-dom";
 import Button from "../../components/Button";
 import { loginUser } from "../../services/auth/AuthService.mjs";
 
 const LoginPage = () => {
-  const { login } = useContext(AuthContext); // 로그인 함수 가져오기
+  const login = useAuthStore((state) => state.login);  // useContext 대신 zustand 사용
   const [userEmail, setUserEmail] = useState("");
   const [password, setPassword] = useState("");
   const navigate = useNavigate();

--- a/frontend/src/pages/classroom/ClassroomDetailPage.js
+++ b/frontend/src/pages/classroom/ClassroomDetailPage.js
@@ -21,10 +21,12 @@ import AttendancePage from "./inClass/attendance/AttendancePage";
 import AssignmentPage from "./inClass/assessment/Assignment";
 import StudyGroupPage from "./inClass/studygroup/StudyGroupPage";
 import Button from "../../components/Button";
+import useAuthStore from "../../stores/authStore";
 
-const ClassroomDetailPage = ({ userInfo }) => {
+const ClassroomDetailPage = () => {
   const { classId } = useParams();
   const [classroomInfo, setClassroomInfo] = useState(null);
+  const userInfo = useAuthStore((state) => state.userInfo);
 
   useEffect(() => {
     // API 호출로 클래스 상세 정보 가져오기

--- a/frontend/src/pages/classroom/preClass/enrollment/EnrollmentBoardPage.js
+++ b/frontend/src/pages/classroom/preClass/enrollment/EnrollmentBoardPage.js
@@ -5,7 +5,7 @@ const EnrollmentBoardPage = ({ userInfo }) => {
   return (
     <div>
       <h2>수업신청 목록조회 페이지를 만듦</h2>
-      <EnrollmentList userInfo={userInfo} />
+      <EnrollmentList />
     </div>
   );
 };

--- a/frontend/src/pages/classroom/preClass/inquiry/InquiryDetailPage.js
+++ b/frontend/src/pages/classroom/preClass/inquiry/InquiryDetailPage.js
@@ -1,5 +1,6 @@
 import { useParams } from "react-router-dom";
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect } from "react";
+import useAuthStore from "../../../../stores/authStore";
 import {
   createComment,
   deleteComment,
@@ -17,7 +18,7 @@ const InquiryDetailPage = () => {
   const { inquiryId } = useParams();
   const [inquiry, setInquiry] = useState(null);
   const [comments, setComments] = useState([]);
-  const { userInfo } = useContext(AuthContext);
+  const userInfo = useAuthStore((state) => state.userInfo);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/frontend/src/pages/home/HomePage.js
+++ b/frontend/src/pages/home/HomePage.js
@@ -1,10 +1,10 @@
-import React, { useContext } from "react";
-import { AuthContext } from "../../context/AuthContext";
+import React from "react";
 import { makeDummyUser } from "../../services/user/UserService.mjs";
 import Button from "../../components/Button";
+import useAuthStore from "../../stores/authStore";  // zustand store import
 
 const HomePage = () => {
-  const { isAuthenticated } = useContext(AuthContext);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   const makeDummy = async () => {
     await makeDummyUser();

--- a/frontend/src/pages/teacher/OfficialProfilePage.js
+++ b/frontend/src/pages/teacher/OfficialProfilePage.js
@@ -1,11 +1,11 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { AuthContext } from "../../context/AuthContext";
+import useAuthStore from "../../stores/authStore";
 import { ReadOfficialProfile } from "../../services/OfficialProfileService.mjs";
 import Button from "../../components/Button";
 
 const OfficialProfilePage = () => {
-  const { userInfo } = useContext(AuthContext);
+  const userInfo = useAuthStore((state) => state.userInfo);
   const { id } = useParams();
   const navigate = useNavigate();
 

--- a/frontend/src/pages/user/ProfilePage.js
+++ b/frontend/src/pages/user/ProfilePage.js
@@ -12,14 +12,15 @@ import GuestBook from "../../components/user/GuestBook";
 import "./ProfilePage.css";
 import Bio from "../../components/user/Bio";
 import Button from "../../components/Button";
+import useAuthStore from "../../stores/authStore";
 
-const ProfilePage = ({ userInfo }) => {
+const ProfilePage = () => {
   const { id } = useParams();
   const [user, setUser] = useState(null); // 유저 정보
   const [bio, setBio] = useState(null); // 유저 자기소개
   const [isEditingUser, setIsEditingUser] = useState(false); // 사용자 정보 수정 모드
   const [isEditingBio, setIsEditingBio] = useState(false); // 자기소개 수정 모드
-
+  const userInfo = useAuthStore((state) => state.userInfo);
   useEffect(() => {
     const fetchUserProfile = async () => {
       const data = await readUser(id);

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -1,0 +1,61 @@
+import { create } from 'zustand';
+import { parseJwtToken } from "../utils/auth/parseJwtToken";
+
+const useAuthStore = create((set) => ({
+  isAuthenticated: false,
+  userInfo: {
+    name: "",
+    id: "",
+    level: "",
+    role: "",
+  },
+  
+  // 로그인 처리
+  login: (userId) => {
+    const user = parseJwtToken(userId);
+    
+    if (user) {
+      set({ 
+        userInfo: user,
+        isAuthenticated: true 
+      });
+      return user.id;
+    }
+
+    // 토큰이 없을 경우 userId만 설정
+    set(state => ({ 
+      userInfo: { ...state.userInfo, id: userId },
+      isAuthenticated: true
+    }));
+  },
+  
+  // 로그아웃 처리
+  logout: () => {
+    set({ 
+      isAuthenticated: false, 
+      userInfo: {
+        name: "",
+        id: "",
+        level: "",
+        role: "",
+      }
+    });
+    
+    // 로컬 스토리지 클리어
+    localStorage.removeItem("jwtToken");
+    localStorage.removeItem("user");
+  },
+
+  // 초기화 함수
+  initialize: () => {
+    const user = parseJwtToken();
+    if (user) {
+      set({
+        isAuthenticated: true,
+        userInfo: user
+      });
+    }
+  }
+}));
+
+export default useAuthStore; 

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "ideal-study-mvp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/node_modules/zustand/LICENSE
+++ b/node_modules/zustand/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Paul Henschel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/zustand/esm/index.d.mts
+++ b/node_modules/zustand/esm/index.d.mts
@@ -1,0 +1,2 @@
+export * from 'zustand/vanilla';
+export * from 'zustand/react';

--- a/node_modules/zustand/esm/index.mjs
+++ b/node_modules/zustand/esm/index.mjs
@@ -1,0 +1,2 @@
+export * from 'zustand/vanilla';
+export * from 'zustand/react';

--- a/node_modules/zustand/esm/middleware.d.mts
+++ b/node_modules/zustand/esm/middleware.d.mts
@@ -1,0 +1,5 @@
+export * from './middleware/redux.mjs';
+export * from './middleware/devtools.mjs';
+export * from './middleware/subscribeWithSelector.mjs';
+export * from './middleware/combine.mjs';
+export * from './middleware/persist.mjs';

--- a/node_modules/zustand/esm/middleware.mjs
+++ b/node_modules/zustand/esm/middleware.mjs
@@ -1,0 +1,433 @@
+const reduxImpl = (reducer, initial) => (set, _get, api) => {
+  api.dispatch = (action) => {
+    set((state) => reducer(state, action), false, action);
+    return action;
+  };
+  api.dispatchFromDevtools = true;
+  return { dispatch: (...a) => api.dispatch(...a), ...initial };
+};
+const redux = reduxImpl;
+
+const trackedConnections = /* @__PURE__ */ new Map();
+const getTrackedConnectionState = (name) => {
+  const api = trackedConnections.get(name);
+  if (!api) return {};
+  return Object.fromEntries(
+    Object.entries(api.stores).map(([key, api2]) => [key, api2.getState()])
+  );
+};
+const extractConnectionInformation = (store, extensionConnector, options) => {
+  if (store === undefined) {
+    return {
+      type: "untracked",
+      connection: extensionConnector.connect(options)
+    };
+  }
+  const existingConnection = trackedConnections.get(options.name);
+  if (existingConnection) {
+    return { type: "tracked", store, ...existingConnection };
+  }
+  const newConnection = {
+    connection: extensionConnector.connect(options),
+    stores: {}
+  };
+  trackedConnections.set(options.name, newConnection);
+  return { type: "tracked", store, ...newConnection };
+};
+const devtoolsImpl = (fn, devtoolsOptions = {}) => (set, get, api) => {
+  const { enabled, anonymousActionType, store, ...options } = devtoolsOptions;
+  let extensionConnector;
+  try {
+    extensionConnector = (enabled != null ? enabled : (import.meta.env ? import.meta.env.MODE : void 0) !== "production") && window.__REDUX_DEVTOOLS_EXTENSION__;
+  } catch (e) {
+  }
+  if (!extensionConnector) {
+    return fn(set, get, api);
+  }
+  const { connection, ...connectionInformation } = extractConnectionInformation(store, extensionConnector, options);
+  let isRecording = true;
+  api.setState = (state, replace, nameOrAction) => {
+    const r = set(state, replace);
+    if (!isRecording) return r;
+    const action = nameOrAction === undefined ? { type: anonymousActionType || "anonymous" } : typeof nameOrAction === "string" ? { type: nameOrAction } : nameOrAction;
+    if (store === undefined) {
+      connection == null ? undefined : connection.send(action, get());
+      return r;
+    }
+    connection == null ? undefined : connection.send(
+      {
+        ...action,
+        type: `${store}/${action.type}`
+      },
+      {
+        ...getTrackedConnectionState(options.name),
+        [store]: api.getState()
+      }
+    );
+    return r;
+  };
+  const setStateFromDevtools = (...a) => {
+    const originalIsRecording = isRecording;
+    isRecording = false;
+    set(...a);
+    isRecording = originalIsRecording;
+  };
+  const initialState = fn(api.setState, get, api);
+  if (connectionInformation.type === "untracked") {
+    connection == null ? undefined : connection.init(initialState);
+  } else {
+    connectionInformation.stores[connectionInformation.store] = api;
+    connection == null ? undefined : connection.init(
+      Object.fromEntries(
+        Object.entries(connectionInformation.stores).map(([key, store2]) => [
+          key,
+          key === connectionInformation.store ? initialState : store2.getState()
+        ])
+      )
+    );
+  }
+  if (api.dispatchFromDevtools && typeof api.dispatch === "function") {
+    let didWarnAboutReservedActionType = false;
+    const originalDispatch = api.dispatch;
+    api.dispatch = (...a) => {
+      if ((import.meta.env ? import.meta.env.MODE : undefined) !== "production" && a[0].type === "__setState" && !didWarnAboutReservedActionType) {
+        console.warn(
+          '[zustand devtools middleware] "__setState" action type is reserved to set state from the devtools. Avoid using it.'
+        );
+        didWarnAboutReservedActionType = true;
+      }
+      originalDispatch(...a);
+    };
+  }
+  connection.subscribe((message) => {
+    var _a;
+    switch (message.type) {
+      case "ACTION":
+        if (typeof message.payload !== "string") {
+          console.error(
+            "[zustand devtools middleware] Unsupported action format"
+          );
+          return;
+        }
+        return parseJsonThen(
+          message.payload,
+          (action) => {
+            if (action.type === "__setState") {
+              if (store === undefined) {
+                setStateFromDevtools(action.state);
+                return;
+              }
+              if (Object.keys(action.state).length !== 1) {
+                console.error(
+                  `
+                    [zustand devtools middleware] Unsupported __setState action format.
+                    When using 'store' option in devtools(), the 'state' should have only one key, which is a value of 'store' that was passed in devtools(),
+                    and value of this only key should be a state object. Example: { "type": "__setState", "state": { "abc123Store": { "foo": "bar" } } }
+                    `
+                );
+              }
+              const stateFromDevtools = action.state[store];
+              if (stateFromDevtools === undefined || stateFromDevtools === null) {
+                return;
+              }
+              if (JSON.stringify(api.getState()) !== JSON.stringify(stateFromDevtools)) {
+                setStateFromDevtools(stateFromDevtools);
+              }
+              return;
+            }
+            if (!api.dispatchFromDevtools) return;
+            if (typeof api.dispatch !== "function") return;
+            api.dispatch(action);
+          }
+        );
+      case "DISPATCH":
+        switch (message.payload.type) {
+          case "RESET":
+            setStateFromDevtools(initialState);
+            if (store === undefined) {
+              return connection == null ? undefined : connection.init(api.getState());
+            }
+            return connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+          case "COMMIT":
+            if (store === undefined) {
+              connection == null ? undefined : connection.init(api.getState());
+              return;
+            }
+            return connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+          case "ROLLBACK":
+            return parseJsonThen(message.state, (state) => {
+              if (store === undefined) {
+                setStateFromDevtools(state);
+                connection == null ? undefined : connection.init(api.getState());
+                return;
+              }
+              setStateFromDevtools(state[store]);
+              connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+            });
+          case "JUMP_TO_STATE":
+          case "JUMP_TO_ACTION":
+            return parseJsonThen(message.state, (state) => {
+              if (store === undefined) {
+                setStateFromDevtools(state);
+                return;
+              }
+              if (JSON.stringify(api.getState()) !== JSON.stringify(state[store])) {
+                setStateFromDevtools(state[store]);
+              }
+            });
+          case "IMPORT_STATE": {
+            const { nextLiftedState } = message.payload;
+            const lastComputedState = (_a = nextLiftedState.computedStates.slice(-1)[0]) == null ? undefined : _a.state;
+            if (!lastComputedState) return;
+            if (store === undefined) {
+              setStateFromDevtools(lastComputedState);
+            } else {
+              setStateFromDevtools(lastComputedState[store]);
+            }
+            connection == null ? undefined : connection.send(
+              null,
+              // FIXME no-any
+              nextLiftedState
+            );
+            return;
+          }
+          case "PAUSE_RECORDING":
+            return isRecording = !isRecording;
+        }
+        return;
+    }
+  });
+  return initialState;
+};
+const devtools = devtoolsImpl;
+const parseJsonThen = (stringified, f) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(stringified);
+  } catch (e) {
+    console.error(
+      "[zustand devtools middleware] Could not parse the received json",
+      e
+    );
+  }
+  if (parsed !== undefined) f(parsed);
+};
+
+const subscribeWithSelectorImpl = (fn) => (set, get, api) => {
+  const origSubscribe = api.subscribe;
+  api.subscribe = (selector, optListener, options) => {
+    let listener = selector;
+    if (optListener) {
+      const equalityFn = (options == null ? undefined : options.equalityFn) || Object.is;
+      let currentSlice = selector(api.getState());
+      listener = (state) => {
+        const nextSlice = selector(state);
+        if (!equalityFn(currentSlice, nextSlice)) {
+          const previousSlice = currentSlice;
+          optListener(currentSlice = nextSlice, previousSlice);
+        }
+      };
+      if (options == null ? undefined : options.fireImmediately) {
+        optListener(currentSlice, currentSlice);
+      }
+    }
+    return origSubscribe(listener);
+  };
+  const initialState = fn(set, get, api);
+  return initialState;
+};
+const subscribeWithSelector = subscribeWithSelectorImpl;
+
+const combine = (initialState, create) => (...a) => Object.assign({}, initialState, create(...a));
+
+function createJSONStorage(getStorage, options) {
+  let storage;
+  try {
+    storage = getStorage();
+  } catch (e) {
+    return;
+  }
+  const persistStorage = {
+    getItem: (name) => {
+      var _a;
+      const parse = (str2) => {
+        if (str2 === null) {
+          return null;
+        }
+        return JSON.parse(str2, options == null ? undefined : options.reviver);
+      };
+      const str = (_a = storage.getItem(name)) != null ? _a : null;
+      if (str instanceof Promise) {
+        return str.then(parse);
+      }
+      return parse(str);
+    },
+    setItem: (name, newValue) => storage.setItem(
+      name,
+      JSON.stringify(newValue, options == null ? undefined : options.replacer)
+    ),
+    removeItem: (name) => storage.removeItem(name)
+  };
+  return persistStorage;
+}
+const toThenable = (fn) => (input) => {
+  try {
+    const result = fn(input);
+    if (result instanceof Promise) {
+      return result;
+    }
+    return {
+      then(onFulfilled) {
+        return toThenable(onFulfilled)(result);
+      },
+      catch(_onRejected) {
+        return this;
+      }
+    };
+  } catch (e) {
+    return {
+      then(_onFulfilled) {
+        return this;
+      },
+      catch(onRejected) {
+        return toThenable(onRejected)(e);
+      }
+    };
+  }
+};
+const persistImpl = (config, baseOptions) => (set, get, api) => {
+  let options = {
+    storage: createJSONStorage(() => localStorage),
+    partialize: (state) => state,
+    version: 0,
+    merge: (persistedState, currentState) => ({
+      ...currentState,
+      ...persistedState
+    }),
+    ...baseOptions
+  };
+  let hasHydrated = false;
+  const hydrationListeners = /* @__PURE__ */ new Set();
+  const finishHydrationListeners = /* @__PURE__ */ new Set();
+  let storage = options.storage;
+  if (!storage) {
+    return config(
+      (...args) => {
+        console.warn(
+          `[zustand persist middleware] Unable to update item '${options.name}', the given storage is currently unavailable.`
+        );
+        set(...args);
+      },
+      get,
+      api
+    );
+  }
+  const setItem = () => {
+    const state = options.partialize({ ...get() });
+    return storage.setItem(options.name, {
+      state,
+      version: options.version
+    });
+  };
+  const savedSetState = api.setState;
+  api.setState = (state, replace) => {
+    savedSetState(state, replace);
+    void setItem();
+  };
+  const configResult = config(
+    (...args) => {
+      set(...args);
+      void setItem();
+    },
+    get,
+    api
+  );
+  api.getInitialState = () => configResult;
+  let stateFromStorage;
+  const hydrate = () => {
+    var _a, _b;
+    if (!storage) return;
+    hasHydrated = false;
+    hydrationListeners.forEach((cb) => {
+      var _a2;
+      return cb((_a2 = get()) != null ? _a2 : configResult);
+    });
+    const postRehydrationCallback = ((_b = options.onRehydrateStorage) == null ? undefined : _b.call(options, (_a = get()) != null ? _a : configResult)) || undefined;
+    return toThenable(storage.getItem.bind(storage))(options.name).then((deserializedStorageValue) => {
+      if (deserializedStorageValue) {
+        if (typeof deserializedStorageValue.version === "number" && deserializedStorageValue.version !== options.version) {
+          if (options.migrate) {
+            const migration = options.migrate(
+              deserializedStorageValue.state,
+              deserializedStorageValue.version
+            );
+            if (migration instanceof Promise) {
+              return migration.then((result) => [true, result]);
+            }
+            return [true, migration];
+          }
+          console.error(
+            `State loaded from storage couldn't be migrated since no migrate function was provided`
+          );
+        } else {
+          return [false, deserializedStorageValue.state];
+        }
+      }
+      return [false, undefined];
+    }).then((migrationResult) => {
+      var _a2;
+      const [migrated, migratedState] = migrationResult;
+      stateFromStorage = options.merge(
+        migratedState,
+        (_a2 = get()) != null ? _a2 : configResult
+      );
+      set(stateFromStorage, true);
+      if (migrated) {
+        return setItem();
+      }
+    }).then(() => {
+      postRehydrationCallback == null ? undefined : postRehydrationCallback(stateFromStorage, undefined);
+      stateFromStorage = get();
+      hasHydrated = true;
+      finishHydrationListeners.forEach((cb) => cb(stateFromStorage));
+    }).catch((e) => {
+      postRehydrationCallback == null ? undefined : postRehydrationCallback(undefined, e);
+    });
+  };
+  api.persist = {
+    setOptions: (newOptions) => {
+      options = {
+        ...options,
+        ...newOptions
+      };
+      if (newOptions.storage) {
+        storage = newOptions.storage;
+      }
+    },
+    clearStorage: () => {
+      storage == null ? undefined : storage.removeItem(options.name);
+    },
+    getOptions: () => options,
+    rehydrate: () => hydrate(),
+    hasHydrated: () => hasHydrated,
+    onHydrate: (cb) => {
+      hydrationListeners.add(cb);
+      return () => {
+        hydrationListeners.delete(cb);
+      };
+    },
+    onFinishHydration: (cb) => {
+      finishHydrationListeners.add(cb);
+      return () => {
+        finishHydrationListeners.delete(cb);
+      };
+    }
+  };
+  if (!options.skipHydration) {
+    hydrate();
+  }
+  return stateFromStorage || configResult;
+};
+const persist = persistImpl;
+
+export { combine, createJSONStorage, devtools, persist, redux, subscribeWithSelector };

--- a/node_modules/zustand/esm/middleware/combine.d.mts
+++ b/node_modules/zustand/esm/middleware/combine.d.mts
@@ -1,0 +1,5 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Write<T, U> = Omit<T, keyof U> & U;
+type Combine = <T extends object, U extends object, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initialState: T, additionalStateCreator: StateCreator<T, Mps, Mcs, U>) => StateCreator<Write<T, U>, Mps, Mcs>;
+export declare const combine: Combine;
+export {};

--- a/node_modules/zustand/esm/middleware/devtools.d.mts
+++ b/node_modules/zustand/esm/middleware/devtools.d.mts
@@ -1,0 +1,55 @@
+import type { StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Config = Parameters<(Window extends {
+    __REDUX_DEVTOOLS_EXTENSION__?: infer T;
+} ? T : {
+    connect: (param: any) => any;
+})['connect']>[0];
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        'zustand/devtools': WithDevtools<S>;
+    }
+}
+type Cast<T, U> = T extends U ? T : U;
+type Write<T, U> = Omit<T, keyof U> & U;
+type TakeTwo<T> = T extends {
+    length: 0;
+} ? [undefined, undefined] : T extends {
+    length: 1;
+} ? [...a0: Cast<T, unknown[]>, a1: undefined] : T extends {
+    length: 0 | 1;
+} ? [...a0: Cast<T, unknown[]>, a1: undefined] : T extends {
+    length: 2;
+} ? T : T extends {
+    length: 1 | 2;
+} ? T : T extends {
+    length: 0 | 1 | 2;
+} ? T : T extends [infer A0, infer A1, ...unknown[]] ? [A0, A1] : T extends [infer A0, (infer A1)?, ...unknown[]] ? [A0, A1?] : T extends [(infer A0)?, (infer A1)?, ...unknown[]] ? [A0?, A1?] : never;
+type WithDevtools<S> = Write<S, StoreDevtools<S>>;
+type Action = string | {
+    type: string;
+    [x: string | number | symbol]: unknown;
+};
+type StoreDevtools<S> = S extends {
+    setState: {
+        (...a: infer Sa1): infer Sr1;
+        (...a: infer Sa2): infer Sr2;
+    };
+} ? {
+    setState(...a: [...a: TakeTwo<Sa1>, action?: Action]): Sr1;
+    setState(...a: [...a: TakeTwo<Sa2>, action?: Action]): Sr2;
+} : never;
+export interface DevtoolsOptions extends Config {
+    name?: string;
+    enabled?: boolean;
+    anonymousActionType?: string;
+    store?: string;
+}
+type Devtools = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = [], U = T>(initializer: StateCreator<T, [...Mps, ['zustand/devtools', never]], Mcs, U>, devtoolsOptions?: DevtoolsOptions) => StateCreator<T, Mps, [['zustand/devtools', never], ...Mcs]>;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        'zustand/devtools': WithDevtools<S>;
+    }
+}
+export type NamedSet<T> = WithDevtools<StoreApi<T>>['setState'];
+export declare const devtools: Devtools;
+export {};

--- a/node_modules/zustand/esm/middleware/immer.d.mts
+++ b/node_modules/zustand/esm/middleware/immer.d.mts
@@ -1,0 +1,29 @@
+import type { Draft } from 'immer';
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Immer = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [...Mps, ['zustand/immer', never]], Mcs>) => StateCreator<T, Mps, [['zustand/immer', never], ...Mcs]>;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        ['zustand/immer']: WithImmer<S>;
+    }
+}
+type Write<T, U> = Omit<T, keyof U> & U;
+type SkipTwo<T> = T extends {
+    length: 0;
+} ? [] : T extends {
+    length: 1;
+} ? [] : T extends {
+    length: 0 | 1;
+} ? [] : T extends [unknown, unknown, ...infer A] ? A : T extends [unknown, unknown?, ...infer A] ? A : T extends [unknown?, unknown?, ...infer A] ? A : never;
+type SetStateType<T extends unknown[]> = Exclude<T[0], (...args: any[]) => any>;
+type WithImmer<S> = Write<S, StoreImmer<S>>;
+type StoreImmer<S> = S extends {
+    setState: infer SetState;
+} ? SetState extends {
+    (...a: infer A1): infer Sr1;
+    (...a: infer A2): infer Sr2;
+} ? {
+    setState(nextStateOrUpdater: SetStateType<A2> | Partial<SetStateType<A2>> | ((state: Draft<SetStateType<A2>>) => void), shouldReplace?: false, ...a: SkipTwo<A1>): Sr1;
+    setState(nextStateOrUpdater: SetStateType<A2> | ((state: Draft<SetStateType<A2>>) => void), shouldReplace: true, ...a: SkipTwo<A2>): Sr2;
+} : never : never;
+export declare const immer: Immer;
+export {};

--- a/node_modules/zustand/esm/middleware/immer.mjs
+++ b/node_modules/zustand/esm/middleware/immer.mjs
@@ -1,0 +1,12 @@
+import { produce } from 'immer';
+
+const immerImpl = (initializer) => (set, get, store) => {
+  store.setState = (updater, replace, ...a) => {
+    const nextState = typeof updater === "function" ? produce(updater) : updater;
+    return set(nextState, replace, ...a);
+  };
+  return initializer(store.setState, get, store);
+};
+const immer = immerImpl;
+
+export { immer };

--- a/node_modules/zustand/esm/middleware/persist.d.mts
+++ b/node_modules/zustand/esm/middleware/persist.d.mts
@@ -1,0 +1,93 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+export interface StateStorage {
+    getItem: (name: string) => string | null | Promise<string | null>;
+    setItem: (name: string, value: string) => unknown | Promise<unknown>;
+    removeItem: (name: string) => unknown | Promise<unknown>;
+}
+export type StorageValue<S> = {
+    state: S;
+    version?: number;
+};
+export interface PersistStorage<S> {
+    getItem: (name: string) => StorageValue<S> | null | Promise<StorageValue<S> | null>;
+    setItem: (name: string, value: StorageValue<S>) => unknown | Promise<unknown>;
+    removeItem: (name: string) => unknown | Promise<unknown>;
+}
+type JsonStorageOptions = {
+    reviver?: (key: string, value: unknown) => unknown;
+    replacer?: (key: string, value: unknown) => unknown;
+};
+export declare function createJSONStorage<S>(getStorage: () => StateStorage, options?: JsonStorageOptions): PersistStorage<S> | undefined;
+export interface PersistOptions<S, PersistedState = S> {
+    /** Name of the storage (must be unique) */
+    name: string;
+    /**
+     * Use a custom persist storage.
+     *
+     * Combining `createJSONStorage` helps creating a persist storage
+     * with JSON.parse and JSON.stringify.
+     *
+     * @default createJSONStorage(() => localStorage)
+     */
+    storage?: PersistStorage<PersistedState> | undefined;
+    /**
+     * Filter the persisted value.
+     *
+     * @params state The state's value
+     */
+    partialize?: (state: S) => PersistedState;
+    /**
+     * A function returning another (optional) function.
+     * The main function will be called before the state rehydration.
+     * The returned function will be called after the state rehydration or when an error occurred.
+     */
+    onRehydrateStorage?: (state: S) => ((state?: S, error?: unknown) => void) | void;
+    /**
+     * If the stored state's version mismatch the one specified here, the storage will not be used.
+     * This is useful when adding a breaking change to your store.
+     */
+    version?: number;
+    /**
+     * A function to perform persisted state migration.
+     * This function will be called when persisted state versions mismatch with the one specified here.
+     */
+    migrate?: (persistedState: unknown, version: number) => PersistedState | Promise<PersistedState>;
+    /**
+     * A function to perform custom hydration merges when combining the stored state with the current one.
+     * By default, this function does a shallow merge.
+     */
+    merge?: (persistedState: unknown, currentState: S) => S;
+    /**
+     * An optional boolean that will prevent the persist middleware from triggering hydration on initialization,
+     * This allows you to call `rehydrate()` at a specific point in your apps rendering life-cycle.
+     *
+     * This is useful in SSR application.
+     *
+     * @default false
+     */
+    skipHydration?: boolean;
+}
+type PersistListener<S> = (state: S) => void;
+type StorePersist<S, Ps> = {
+    persist: {
+        setOptions: (options: Partial<PersistOptions<S, Ps>>) => void;
+        clearStorage: () => void;
+        rehydrate: () => Promise<void> | void;
+        hasHydrated: () => boolean;
+        onHydrate: (fn: PersistListener<S>) => () => void;
+        onFinishHydration: (fn: PersistListener<S>) => () => void;
+        getOptions: () => Partial<PersistOptions<S, Ps>>;
+    };
+};
+type Persist = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = [], U = T>(initializer: StateCreator<T, [...Mps, ['zustand/persist', unknown]], Mcs>, options: PersistOptions<T, U>) => StateCreator<T, Mps, [['zustand/persist', U], ...Mcs]>;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        'zustand/persist': WithPersist<S, A>;
+    }
+}
+type Write<T, U> = Omit<T, keyof U> & U;
+type WithPersist<S, A> = S extends {
+    getState: () => infer T;
+} ? Write<S, StorePersist<T, A>> : never;
+export declare const persist: Persist;
+export {};

--- a/node_modules/zustand/esm/middleware/redux.d.mts
+++ b/node_modules/zustand/esm/middleware/redux.d.mts
@@ -1,0 +1,21 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Write<T, U> = Omit<T, keyof U> & U;
+type Action = {
+    type: string;
+};
+type StoreRedux<A> = {
+    dispatch: (a: A) => A;
+    dispatchFromDevtools: true;
+};
+type ReduxState<A> = {
+    dispatch: StoreRedux<A>['dispatch'];
+};
+type WithRedux<S, A> = Write<S, StoreRedux<A>>;
+type Redux = <T, A extends Action, Cms extends [StoreMutatorIdentifier, unknown][] = []>(reducer: (state: T, action: A) => T, initialState: T) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        'zustand/redux': WithRedux<S, A>;
+    }
+}
+export declare const redux: Redux;
+export {};

--- a/node_modules/zustand/esm/middleware/subscribeWithSelector.d.mts
+++ b/node_modules/zustand/esm/middleware/subscribeWithSelector.d.mts
@@ -1,0 +1,25 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type SubscribeWithSelector = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [
+    ...Mps,
+    ['zustand/subscribeWithSelector', never]
+], Mcs>) => StateCreator<T, Mps, [['zustand/subscribeWithSelector', never], ...Mcs]>;
+type Write<T, U> = Omit<T, keyof U> & U;
+type WithSelectorSubscribe<S> = S extends {
+    getState: () => infer T;
+} ? Write<S, StoreSubscribeWithSelector<T>> : never;
+declare module '../vanilla.mjs' {
+    interface StoreMutators<S, A> {
+        ['zustand/subscribeWithSelector']: WithSelectorSubscribe<S>;
+    }
+}
+type StoreSubscribeWithSelector<T> = {
+    subscribe: {
+        (listener: (selectedState: T, previousSelectedState: T) => void): () => void;
+        <U>(selector: (state: T) => U, listener: (selectedState: U, previousSelectedState: U) => void, options?: {
+            equalityFn?: (a: U, b: U) => boolean;
+            fireImmediately?: boolean;
+        }): () => void;
+    };
+};
+export declare const subscribeWithSelector: SubscribeWithSelector;
+export {};

--- a/node_modules/zustand/esm/react.d.mts
+++ b/node_modules/zustand/esm/react.d.mts
@@ -1,0 +1,14 @@
+import type { ExtractState, Mutate, StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 'subscribe'>;
+export declare function useStore<S extends ReadonlyStoreApi<unknown>>(api: S): ExtractState<S>;
+export declare function useStore<S extends ReadonlyStoreApi<unknown>, U>(api: S, selector: (state: ExtractState<S>) => U): U;
+export type UseBoundStore<S extends ReadonlyStoreApi<unknown>> = {
+    (): ExtractState<S>;
+    <U>(selector: (state: ExtractState<S>) => U): U;
+} & S;
+type Create = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>): UseBoundStore<Mutate<StoreApi<T>, Mos>>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>) => UseBoundStore<Mutate<StoreApi<T>, Mos>>;
+};
+export declare const create: Create;
+export {};

--- a/node_modules/zustand/esm/react.mjs
+++ b/node_modules/zustand/esm/react.mjs
@@ -1,0 +1,22 @@
+import React from 'react';
+import { createStore } from 'zustand/vanilla';
+
+const identity = (arg) => arg;
+function useStore(api, selector = identity) {
+  const slice = React.useSyncExternalStore(
+    api.subscribe,
+    () => selector(api.getState()),
+    () => selector(api.getInitialState())
+  );
+  React.useDebugValue(slice);
+  return slice;
+}
+const createImpl = (createState) => {
+  const api = createStore(createState);
+  const useBoundStore = (selector) => useStore(api, selector);
+  Object.assign(useBoundStore, api);
+  return useBoundStore;
+};
+const create = (createState) => createState ? createImpl(createState) : createImpl;
+
+export { create, useStore };

--- a/node_modules/zustand/esm/react/shallow.d.mts
+++ b/node_modules/zustand/esm/react/shallow.d.mts
@@ -1,0 +1,1 @@
+export declare function useShallow<S, U>(selector: (state: S) => U): (state: S) => U;

--- a/node_modules/zustand/esm/react/shallow.mjs
+++ b/node_modules/zustand/esm/react/shallow.mjs
@@ -1,0 +1,12 @@
+import React from 'react';
+import { shallow } from 'zustand/vanilla/shallow';
+
+function useShallow(selector) {
+  const prev = React.useRef(undefined);
+  return (state) => {
+    const next = selector(state);
+    return shallow(prev.current, next) ? prev.current : prev.current = next;
+  };
+}
+
+export { useShallow };

--- a/node_modules/zustand/esm/shallow.d.mts
+++ b/node_modules/zustand/esm/shallow.d.mts
@@ -1,0 +1,2 @@
+export { shallow } from 'zustand/vanilla/shallow';
+export { useShallow } from 'zustand/react/shallow';

--- a/node_modules/zustand/esm/shallow.mjs
+++ b/node_modules/zustand/esm/shallow.mjs
@@ -1,0 +1,2 @@
+export { shallow } from 'zustand/vanilla/shallow';
+export { useShallow } from 'zustand/react/shallow';

--- a/node_modules/zustand/esm/traditional.d.mts
+++ b/node_modules/zustand/esm/traditional.d.mts
@@ -1,0 +1,17 @@
+import type { Mutate, StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type ExtractState<S> = S extends {
+    getState: () => infer T;
+} ? T : never;
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 'subscribe'>;
+export declare function useStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>>(api: S): ExtractState<S>;
+export declare function useStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>, U>(api: S, selector: (state: ExtractState<S>) => U, equalityFn?: (a: U, b: U) => boolean): U;
+export type UseBoundStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>> = {
+    (): ExtractState<S>;
+    <U>(selector: (state: ExtractState<S>) => U, equalityFn?: (a: U, b: U) => boolean): U;
+} & S;
+type CreateWithEqualityFn = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>, defaultEqualityFn?: <U>(a: U, b: U) => boolean): UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>, defaultEqualityFn?: <U>(a: U, b: U) => boolean) => UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>;
+};
+export declare const createWithEqualityFn: CreateWithEqualityFn;
+export {};

--- a/node_modules/zustand/esm/traditional.mjs
+++ b/node_modules/zustand/esm/traditional.mjs
@@ -1,0 +1,26 @@
+import React from 'react';
+import useSyncExternalStoreExports from 'use-sync-external-store/shim/with-selector.js';
+import { createStore } from 'zustand/vanilla';
+
+const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports;
+const identity = (arg) => arg;
+function useStoreWithEqualityFn(api, selector = identity, equalityFn) {
+  const slice = useSyncExternalStoreWithSelector(
+    api.subscribe,
+    api.getState,
+    api.getInitialState,
+    selector,
+    equalityFn
+  );
+  React.useDebugValue(slice);
+  return slice;
+}
+const createWithEqualityFnImpl = (createState, defaultEqualityFn) => {
+  const api = createStore(createState);
+  const useBoundStoreWithEqualityFn = (selector, equalityFn = defaultEqualityFn) => useStoreWithEqualityFn(api, selector, equalityFn);
+  Object.assign(useBoundStoreWithEqualityFn, api);
+  return useBoundStoreWithEqualityFn;
+};
+const createWithEqualityFn = (createState, defaultEqualityFn) => createState ? createWithEqualityFnImpl(createState, defaultEqualityFn) : createWithEqualityFnImpl;
+
+export { createWithEqualityFn, useStoreWithEqualityFn };

--- a/node_modules/zustand/esm/vanilla.d.mts
+++ b/node_modules/zustand/esm/vanilla.d.mts
@@ -1,0 +1,31 @@
+type SetStateInternal<T> = {
+    _(partial: T | Partial<T> | {
+        _(state: T): T | Partial<T>;
+    }['_'], replace?: false): void;
+    _(state: T | {
+        _(state: T): T;
+    }['_'], replace: true): void;
+}['_'];
+export interface StoreApi<T> {
+    setState: SetStateInternal<T>;
+    getState: () => T;
+    getInitialState: () => T;
+    subscribe: (listener: (state: T, prevState: T) => void) => () => void;
+}
+export type ExtractState<S> = S extends {
+    getState: () => infer T;
+} ? T : never;
+type Get<T, K, F> = K extends keyof T ? T[K] : F;
+export type Mutate<S, Ms> = number extends Ms['length' & keyof Ms] ? S : Ms extends [] ? S : Ms extends [[infer Mi, infer Ma], ...infer Mrs] ? Mutate<StoreMutators<S, Ma>[Mi & StoreMutatorIdentifier], Mrs> : never;
+export type StateCreator<T, Mis extends [StoreMutatorIdentifier, unknown][] = [], Mos extends [StoreMutatorIdentifier, unknown][] = [], U = T> = ((setState: Get<Mutate<StoreApi<T>, Mis>, 'setState', never>, getState: Get<Mutate<StoreApi<T>, Mis>, 'getState', never>, store: Mutate<StoreApi<T>, Mis>) => U) & {
+    $$storeMutators?: Mos;
+};
+export interface StoreMutators<S, A> {
+}
+export type StoreMutatorIdentifier = keyof StoreMutators<unknown, unknown>;
+type CreateStore = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>): Mutate<StoreApi<T>, Mos>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>) => Mutate<StoreApi<T>, Mos>;
+};
+export declare const createStore: CreateStore;
+export {};

--- a/node_modules/zustand/esm/vanilla.mjs
+++ b/node_modules/zustand/esm/vanilla.mjs
@@ -1,0 +1,24 @@
+const createStoreImpl = (createState) => {
+  let state;
+  const listeners = /* @__PURE__ */ new Set();
+  const setState = (partial, replace) => {
+    const nextState = typeof partial === "function" ? partial(state) : partial;
+    if (!Object.is(nextState, state)) {
+      const previousState = state;
+      state = (replace != null ? replace : typeof nextState !== "object" || nextState === null) ? nextState : Object.assign({}, state, nextState);
+      listeners.forEach((listener) => listener(state, previousState));
+    }
+  };
+  const getState = () => state;
+  const getInitialState = () => initialState;
+  const subscribe = (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+  const api = { setState, getState, getInitialState, subscribe };
+  const initialState = state = createState(setState, getState, api);
+  return api;
+};
+const createStore = (createState) => createState ? createStoreImpl(createState) : createStoreImpl;
+
+export { createStore };

--- a/node_modules/zustand/esm/vanilla/shallow.d.mts
+++ b/node_modules/zustand/esm/vanilla/shallow.d.mts
@@ -1,0 +1,1 @@
+export declare function shallow<T>(valueA: T, valueB: T): boolean;

--- a/node_modules/zustand/esm/vanilla/shallow.mjs
+++ b/node_modules/zustand/esm/vanilla/shallow.mjs
@@ -1,0 +1,52 @@
+const isIterable = (obj) => Symbol.iterator in obj;
+const hasIterableEntries = (value) => (
+  // HACK: avoid checking entries type
+  "entries" in value
+);
+const compareEntries = (valueA, valueB) => {
+  const mapA = valueA instanceof Map ? valueA : new Map(valueA.entries());
+  const mapB = valueB instanceof Map ? valueB : new Map(valueB.entries());
+  if (mapA.size !== mapB.size) {
+    return false;
+  }
+  for (const [key, value] of mapA) {
+    if (!Object.is(value, mapB.get(key))) {
+      return false;
+    }
+  }
+  return true;
+};
+const compareIterables = (valueA, valueB) => {
+  const iteratorA = valueA[Symbol.iterator]();
+  const iteratorB = valueB[Symbol.iterator]();
+  let nextA = iteratorA.next();
+  let nextB = iteratorB.next();
+  while (!nextA.done && !nextB.done) {
+    if (!Object.is(nextA.value, nextB.value)) {
+      return false;
+    }
+    nextA = iteratorA.next();
+    nextB = iteratorB.next();
+  }
+  return !!nextA.done && !!nextB.done;
+};
+function shallow(valueA, valueB) {
+  if (Object.is(valueA, valueB)) {
+    return true;
+  }
+  if (typeof valueA !== "object" || valueA === null || typeof valueB !== "object" || valueB === null) {
+    return false;
+  }
+  if (!isIterable(valueA) || !isIterable(valueB)) {
+    return compareEntries(
+      { entries: () => Object.entries(valueA) },
+      { entries: () => Object.entries(valueB) }
+    );
+  }
+  if (hasIterableEntries(valueA) && hasIterableEntries(valueB)) {
+    return compareEntries(valueA, valueB);
+  }
+  return compareIterables(valueA, valueB);
+}
+
+export { shallow };

--- a/node_modules/zustand/index.d.ts
+++ b/node_modules/zustand/index.d.ts
@@ -1,0 +1,2 @@
+export * from 'zustand/vanilla';
+export * from 'zustand/react';

--- a/node_modules/zustand/index.js
+++ b/node_modules/zustand/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var vanilla = require('zustand/vanilla');
+var react = require('zustand/react');
+
+
+
+Object.keys(vanilla).forEach(function (k) {
+	if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+		enumerable: true,
+		get: function () { return vanilla[k]; }
+	});
+});
+Object.keys(react).forEach(function (k) {
+	if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+		enumerable: true,
+		get: function () { return react[k]; }
+	});
+});

--- a/node_modules/zustand/middleware.d.ts
+++ b/node_modules/zustand/middleware.d.ts
@@ -1,0 +1,5 @@
+export * from './middleware/redux';
+export * from './middleware/devtools';
+export * from './middleware/subscribeWithSelector';
+export * from './middleware/combine';
+export * from './middleware/persist';

--- a/node_modules/zustand/middleware.js
+++ b/node_modules/zustand/middleware.js
@@ -1,0 +1,440 @@
+'use strict';
+
+const reduxImpl = (reducer, initial) => (set, _get, api) => {
+  api.dispatch = (action) => {
+    set((state) => reducer(state, action), false, action);
+    return action;
+  };
+  api.dispatchFromDevtools = true;
+  return { dispatch: (...a) => api.dispatch(...a), ...initial };
+};
+const redux = reduxImpl;
+
+const trackedConnections = /* @__PURE__ */ new Map();
+const getTrackedConnectionState = (name) => {
+  const api = trackedConnections.get(name);
+  if (!api) return {};
+  return Object.fromEntries(
+    Object.entries(api.stores).map(([key, api2]) => [key, api2.getState()])
+  );
+};
+const extractConnectionInformation = (store, extensionConnector, options) => {
+  if (store === undefined) {
+    return {
+      type: "untracked",
+      connection: extensionConnector.connect(options)
+    };
+  }
+  const existingConnection = trackedConnections.get(options.name);
+  if (existingConnection) {
+    return { type: "tracked", store, ...existingConnection };
+  }
+  const newConnection = {
+    connection: extensionConnector.connect(options),
+    stores: {}
+  };
+  trackedConnections.set(options.name, newConnection);
+  return { type: "tracked", store, ...newConnection };
+};
+const devtoolsImpl = (fn, devtoolsOptions = {}) => (set, get, api) => {
+  const { enabled, anonymousActionType, store, ...options } = devtoolsOptions;
+  let extensionConnector;
+  try {
+    extensionConnector = (enabled != null ? enabled : process.env.NODE_ENV !== "production") && window.__REDUX_DEVTOOLS_EXTENSION__;
+  } catch (e) {
+  }
+  if (!extensionConnector) {
+    return fn(set, get, api);
+  }
+  const { connection, ...connectionInformation } = extractConnectionInformation(store, extensionConnector, options);
+  let isRecording = true;
+  api.setState = (state, replace, nameOrAction) => {
+    const r = set(state, replace);
+    if (!isRecording) return r;
+    const action = nameOrAction === undefined ? { type: anonymousActionType || "anonymous" } : typeof nameOrAction === "string" ? { type: nameOrAction } : nameOrAction;
+    if (store === undefined) {
+      connection == null ? undefined : connection.send(action, get());
+      return r;
+    }
+    connection == null ? undefined : connection.send(
+      {
+        ...action,
+        type: `${store}/${action.type}`
+      },
+      {
+        ...getTrackedConnectionState(options.name),
+        [store]: api.getState()
+      }
+    );
+    return r;
+  };
+  const setStateFromDevtools = (...a) => {
+    const originalIsRecording = isRecording;
+    isRecording = false;
+    set(...a);
+    isRecording = originalIsRecording;
+  };
+  const initialState = fn(api.setState, get, api);
+  if (connectionInformation.type === "untracked") {
+    connection == null ? undefined : connection.init(initialState);
+  } else {
+    connectionInformation.stores[connectionInformation.store] = api;
+    connection == null ? undefined : connection.init(
+      Object.fromEntries(
+        Object.entries(connectionInformation.stores).map(([key, store2]) => [
+          key,
+          key === connectionInformation.store ? initialState : store2.getState()
+        ])
+      )
+    );
+  }
+  if (api.dispatchFromDevtools && typeof api.dispatch === "function") {
+    let didWarnAboutReservedActionType = false;
+    const originalDispatch = api.dispatch;
+    api.dispatch = (...a) => {
+      if (process.env.NODE_ENV !== "production" && a[0].type === "__setState" && !didWarnAboutReservedActionType) {
+        console.warn(
+          '[zustand devtools middleware] "__setState" action type is reserved to set state from the devtools. Avoid using it.'
+        );
+        didWarnAboutReservedActionType = true;
+      }
+      originalDispatch(...a);
+    };
+  }
+  connection.subscribe((message) => {
+    var _a;
+    switch (message.type) {
+      case "ACTION":
+        if (typeof message.payload !== "string") {
+          console.error(
+            "[zustand devtools middleware] Unsupported action format"
+          );
+          return;
+        }
+        return parseJsonThen(
+          message.payload,
+          (action) => {
+            if (action.type === "__setState") {
+              if (store === undefined) {
+                setStateFromDevtools(action.state);
+                return;
+              }
+              if (Object.keys(action.state).length !== 1) {
+                console.error(
+                  `
+                    [zustand devtools middleware] Unsupported __setState action format.
+                    When using 'store' option in devtools(), the 'state' should have only one key, which is a value of 'store' that was passed in devtools(),
+                    and value of this only key should be a state object. Example: { "type": "__setState", "state": { "abc123Store": { "foo": "bar" } } }
+                    `
+                );
+              }
+              const stateFromDevtools = action.state[store];
+              if (stateFromDevtools === undefined || stateFromDevtools === null) {
+                return;
+              }
+              if (JSON.stringify(api.getState()) !== JSON.stringify(stateFromDevtools)) {
+                setStateFromDevtools(stateFromDevtools);
+              }
+              return;
+            }
+            if (!api.dispatchFromDevtools) return;
+            if (typeof api.dispatch !== "function") return;
+            api.dispatch(action);
+          }
+        );
+      case "DISPATCH":
+        switch (message.payload.type) {
+          case "RESET":
+            setStateFromDevtools(initialState);
+            if (store === undefined) {
+              return connection == null ? undefined : connection.init(api.getState());
+            }
+            return connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+          case "COMMIT":
+            if (store === undefined) {
+              connection == null ? undefined : connection.init(api.getState());
+              return;
+            }
+            return connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+          case "ROLLBACK":
+            return parseJsonThen(message.state, (state) => {
+              if (store === undefined) {
+                setStateFromDevtools(state);
+                connection == null ? undefined : connection.init(api.getState());
+                return;
+              }
+              setStateFromDevtools(state[store]);
+              connection == null ? undefined : connection.init(getTrackedConnectionState(options.name));
+            });
+          case "JUMP_TO_STATE":
+          case "JUMP_TO_ACTION":
+            return parseJsonThen(message.state, (state) => {
+              if (store === undefined) {
+                setStateFromDevtools(state);
+                return;
+              }
+              if (JSON.stringify(api.getState()) !== JSON.stringify(state[store])) {
+                setStateFromDevtools(state[store]);
+              }
+            });
+          case "IMPORT_STATE": {
+            const { nextLiftedState } = message.payload;
+            const lastComputedState = (_a = nextLiftedState.computedStates.slice(-1)[0]) == null ? undefined : _a.state;
+            if (!lastComputedState) return;
+            if (store === undefined) {
+              setStateFromDevtools(lastComputedState);
+            } else {
+              setStateFromDevtools(lastComputedState[store]);
+            }
+            connection == null ? undefined : connection.send(
+              null,
+              // FIXME no-any
+              nextLiftedState
+            );
+            return;
+          }
+          case "PAUSE_RECORDING":
+            return isRecording = !isRecording;
+        }
+        return;
+    }
+  });
+  return initialState;
+};
+const devtools = devtoolsImpl;
+const parseJsonThen = (stringified, f) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(stringified);
+  } catch (e) {
+    console.error(
+      "[zustand devtools middleware] Could not parse the received json",
+      e
+    );
+  }
+  if (parsed !== undefined) f(parsed);
+};
+
+const subscribeWithSelectorImpl = (fn) => (set, get, api) => {
+  const origSubscribe = api.subscribe;
+  api.subscribe = (selector, optListener, options) => {
+    let listener = selector;
+    if (optListener) {
+      const equalityFn = (options == null ? undefined : options.equalityFn) || Object.is;
+      let currentSlice = selector(api.getState());
+      listener = (state) => {
+        const nextSlice = selector(state);
+        if (!equalityFn(currentSlice, nextSlice)) {
+          const previousSlice = currentSlice;
+          optListener(currentSlice = nextSlice, previousSlice);
+        }
+      };
+      if (options == null ? undefined : options.fireImmediately) {
+        optListener(currentSlice, currentSlice);
+      }
+    }
+    return origSubscribe(listener);
+  };
+  const initialState = fn(set, get, api);
+  return initialState;
+};
+const subscribeWithSelector = subscribeWithSelectorImpl;
+
+const combine = (initialState, create) => (...a) => Object.assign({}, initialState, create(...a));
+
+function createJSONStorage(getStorage, options) {
+  let storage;
+  try {
+    storage = getStorage();
+  } catch (e) {
+    return;
+  }
+  const persistStorage = {
+    getItem: (name) => {
+      var _a;
+      const parse = (str2) => {
+        if (str2 === null) {
+          return null;
+        }
+        return JSON.parse(str2, options == null ? undefined : options.reviver);
+      };
+      const str = (_a = storage.getItem(name)) != null ? _a : null;
+      if (str instanceof Promise) {
+        return str.then(parse);
+      }
+      return parse(str);
+    },
+    setItem: (name, newValue) => storage.setItem(
+      name,
+      JSON.stringify(newValue, options == null ? undefined : options.replacer)
+    ),
+    removeItem: (name) => storage.removeItem(name)
+  };
+  return persistStorage;
+}
+const toThenable = (fn) => (input) => {
+  try {
+    const result = fn(input);
+    if (result instanceof Promise) {
+      return result;
+    }
+    return {
+      then(onFulfilled) {
+        return toThenable(onFulfilled)(result);
+      },
+      catch(_onRejected) {
+        return this;
+      }
+    };
+  } catch (e) {
+    return {
+      then(_onFulfilled) {
+        return this;
+      },
+      catch(onRejected) {
+        return toThenable(onRejected)(e);
+      }
+    };
+  }
+};
+const persistImpl = (config, baseOptions) => (set, get, api) => {
+  let options = {
+    storage: createJSONStorage(() => localStorage),
+    partialize: (state) => state,
+    version: 0,
+    merge: (persistedState, currentState) => ({
+      ...currentState,
+      ...persistedState
+    }),
+    ...baseOptions
+  };
+  let hasHydrated = false;
+  const hydrationListeners = /* @__PURE__ */ new Set();
+  const finishHydrationListeners = /* @__PURE__ */ new Set();
+  let storage = options.storage;
+  if (!storage) {
+    return config(
+      (...args) => {
+        console.warn(
+          `[zustand persist middleware] Unable to update item '${options.name}', the given storage is currently unavailable.`
+        );
+        set(...args);
+      },
+      get,
+      api
+    );
+  }
+  const setItem = () => {
+    const state = options.partialize({ ...get() });
+    return storage.setItem(options.name, {
+      state,
+      version: options.version
+    });
+  };
+  const savedSetState = api.setState;
+  api.setState = (state, replace) => {
+    savedSetState(state, replace);
+    void setItem();
+  };
+  const configResult = config(
+    (...args) => {
+      set(...args);
+      void setItem();
+    },
+    get,
+    api
+  );
+  api.getInitialState = () => configResult;
+  let stateFromStorage;
+  const hydrate = () => {
+    var _a, _b;
+    if (!storage) return;
+    hasHydrated = false;
+    hydrationListeners.forEach((cb) => {
+      var _a2;
+      return cb((_a2 = get()) != null ? _a2 : configResult);
+    });
+    const postRehydrationCallback = ((_b = options.onRehydrateStorage) == null ? undefined : _b.call(options, (_a = get()) != null ? _a : configResult)) || undefined;
+    return toThenable(storage.getItem.bind(storage))(options.name).then((deserializedStorageValue) => {
+      if (deserializedStorageValue) {
+        if (typeof deserializedStorageValue.version === "number" && deserializedStorageValue.version !== options.version) {
+          if (options.migrate) {
+            const migration = options.migrate(
+              deserializedStorageValue.state,
+              deserializedStorageValue.version
+            );
+            if (migration instanceof Promise) {
+              return migration.then((result) => [true, result]);
+            }
+            return [true, migration];
+          }
+          console.error(
+            `State loaded from storage couldn't be migrated since no migrate function was provided`
+          );
+        } else {
+          return [false, deserializedStorageValue.state];
+        }
+      }
+      return [false, undefined];
+    }).then((migrationResult) => {
+      var _a2;
+      const [migrated, migratedState] = migrationResult;
+      stateFromStorage = options.merge(
+        migratedState,
+        (_a2 = get()) != null ? _a2 : configResult
+      );
+      set(stateFromStorage, true);
+      if (migrated) {
+        return setItem();
+      }
+    }).then(() => {
+      postRehydrationCallback == null ? undefined : postRehydrationCallback(stateFromStorage, undefined);
+      stateFromStorage = get();
+      hasHydrated = true;
+      finishHydrationListeners.forEach((cb) => cb(stateFromStorage));
+    }).catch((e) => {
+      postRehydrationCallback == null ? undefined : postRehydrationCallback(undefined, e);
+    });
+  };
+  api.persist = {
+    setOptions: (newOptions) => {
+      options = {
+        ...options,
+        ...newOptions
+      };
+      if (newOptions.storage) {
+        storage = newOptions.storage;
+      }
+    },
+    clearStorage: () => {
+      storage == null ? undefined : storage.removeItem(options.name);
+    },
+    getOptions: () => options,
+    rehydrate: () => hydrate(),
+    hasHydrated: () => hasHydrated,
+    onHydrate: (cb) => {
+      hydrationListeners.add(cb);
+      return () => {
+        hydrationListeners.delete(cb);
+      };
+    },
+    onFinishHydration: (cb) => {
+      finishHydrationListeners.add(cb);
+      return () => {
+        finishHydrationListeners.delete(cb);
+      };
+    }
+  };
+  if (!options.skipHydration) {
+    hydrate();
+  }
+  return stateFromStorage || configResult;
+};
+const persist = persistImpl;
+
+exports.combine = combine;
+exports.createJSONStorage = createJSONStorage;
+exports.devtools = devtools;
+exports.persist = persist;
+exports.redux = redux;
+exports.subscribeWithSelector = subscribeWithSelector;

--- a/node_modules/zustand/middleware/combine.d.ts
+++ b/node_modules/zustand/middleware/combine.d.ts
@@ -1,0 +1,5 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Write<T, U> = Omit<T, keyof U> & U;
+type Combine = <T extends object, U extends object, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initialState: T, additionalStateCreator: StateCreator<T, Mps, Mcs, U>) => StateCreator<Write<T, U>, Mps, Mcs>;
+export declare const combine: Combine;
+export {};

--- a/node_modules/zustand/middleware/devtools.d.ts
+++ b/node_modules/zustand/middleware/devtools.d.ts
@@ -1,0 +1,55 @@
+import type { StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Config = Parameters<(Window extends {
+    __REDUX_DEVTOOLS_EXTENSION__?: infer T;
+} ? T : {
+    connect: (param: any) => any;
+})['connect']>[0];
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        'zustand/devtools': WithDevtools<S>;
+    }
+}
+type Cast<T, U> = T extends U ? T : U;
+type Write<T, U> = Omit<T, keyof U> & U;
+type TakeTwo<T> = T extends {
+    length: 0;
+} ? [undefined, undefined] : T extends {
+    length: 1;
+} ? [...a0: Cast<T, unknown[]>, a1: undefined] : T extends {
+    length: 0 | 1;
+} ? [...a0: Cast<T, unknown[]>, a1: undefined] : T extends {
+    length: 2;
+} ? T : T extends {
+    length: 1 | 2;
+} ? T : T extends {
+    length: 0 | 1 | 2;
+} ? T : T extends [infer A0, infer A1, ...unknown[]] ? [A0, A1] : T extends [infer A0, (infer A1)?, ...unknown[]] ? [A0, A1?] : T extends [(infer A0)?, (infer A1)?, ...unknown[]] ? [A0?, A1?] : never;
+type WithDevtools<S> = Write<S, StoreDevtools<S>>;
+type Action = string | {
+    type: string;
+    [x: string | number | symbol]: unknown;
+};
+type StoreDevtools<S> = S extends {
+    setState: {
+        (...a: infer Sa1): infer Sr1;
+        (...a: infer Sa2): infer Sr2;
+    };
+} ? {
+    setState(...a: [...a: TakeTwo<Sa1>, action?: Action]): Sr1;
+    setState(...a: [...a: TakeTwo<Sa2>, action?: Action]): Sr2;
+} : never;
+export interface DevtoolsOptions extends Config {
+    name?: string;
+    enabled?: boolean;
+    anonymousActionType?: string;
+    store?: string;
+}
+type Devtools = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = [], U = T>(initializer: StateCreator<T, [...Mps, ['zustand/devtools', never]], Mcs, U>, devtoolsOptions?: DevtoolsOptions) => StateCreator<T, Mps, [['zustand/devtools', never], ...Mcs]>;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        'zustand/devtools': WithDevtools<S>;
+    }
+}
+export type NamedSet<T> = WithDevtools<StoreApi<T>>['setState'];
+export declare const devtools: Devtools;
+export {};

--- a/node_modules/zustand/middleware/immer.d.ts
+++ b/node_modules/zustand/middleware/immer.d.ts
@@ -1,0 +1,29 @@
+import type { Draft } from 'immer';
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Immer = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [...Mps, ['zustand/immer', never]], Mcs>) => StateCreator<T, Mps, [['zustand/immer', never], ...Mcs]>;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        ['zustand/immer']: WithImmer<S>;
+    }
+}
+type Write<T, U> = Omit<T, keyof U> & U;
+type SkipTwo<T> = T extends {
+    length: 0;
+} ? [] : T extends {
+    length: 1;
+} ? [] : T extends {
+    length: 0 | 1;
+} ? [] : T extends [unknown, unknown, ...infer A] ? A : T extends [unknown, unknown?, ...infer A] ? A : T extends [unknown?, unknown?, ...infer A] ? A : never;
+type SetStateType<T extends unknown[]> = Exclude<T[0], (...args: any[]) => any>;
+type WithImmer<S> = Write<S, StoreImmer<S>>;
+type StoreImmer<S> = S extends {
+    setState: infer SetState;
+} ? SetState extends {
+    (...a: infer A1): infer Sr1;
+    (...a: infer A2): infer Sr2;
+} ? {
+    setState(nextStateOrUpdater: SetStateType<A2> | Partial<SetStateType<A2>> | ((state: Draft<SetStateType<A2>>) => void), shouldReplace?: false, ...a: SkipTwo<A1>): Sr1;
+    setState(nextStateOrUpdater: SetStateType<A2> | ((state: Draft<SetStateType<A2>>) => void), shouldReplace: true, ...a: SkipTwo<A2>): Sr2;
+} : never : never;
+export declare const immer: Immer;
+export {};

--- a/node_modules/zustand/middleware/immer.js
+++ b/node_modules/zustand/middleware/immer.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var immer$1 = require('immer');
+
+const immerImpl = (initializer) => (set, get, store) => {
+  store.setState = (updater, replace, ...a) => {
+    const nextState = typeof updater === "function" ? immer$1.produce(updater) : updater;
+    return set(nextState, replace, ...a);
+  };
+  return initializer(store.setState, get, store);
+};
+const immer = immerImpl;
+
+exports.immer = immer;

--- a/node_modules/zustand/middleware/persist.d.ts
+++ b/node_modules/zustand/middleware/persist.d.ts
@@ -1,0 +1,93 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+export interface StateStorage {
+    getItem: (name: string) => string | null | Promise<string | null>;
+    setItem: (name: string, value: string) => unknown | Promise<unknown>;
+    removeItem: (name: string) => unknown | Promise<unknown>;
+}
+export type StorageValue<S> = {
+    state: S;
+    version?: number;
+};
+export interface PersistStorage<S> {
+    getItem: (name: string) => StorageValue<S> | null | Promise<StorageValue<S> | null>;
+    setItem: (name: string, value: StorageValue<S>) => unknown | Promise<unknown>;
+    removeItem: (name: string) => unknown | Promise<unknown>;
+}
+type JsonStorageOptions = {
+    reviver?: (key: string, value: unknown) => unknown;
+    replacer?: (key: string, value: unknown) => unknown;
+};
+export declare function createJSONStorage<S>(getStorage: () => StateStorage, options?: JsonStorageOptions): PersistStorage<S> | undefined;
+export interface PersistOptions<S, PersistedState = S> {
+    /** Name of the storage (must be unique) */
+    name: string;
+    /**
+     * Use a custom persist storage.
+     *
+     * Combining `createJSONStorage` helps creating a persist storage
+     * with JSON.parse and JSON.stringify.
+     *
+     * @default createJSONStorage(() => localStorage)
+     */
+    storage?: PersistStorage<PersistedState> | undefined;
+    /**
+     * Filter the persisted value.
+     *
+     * @params state The state's value
+     */
+    partialize?: (state: S) => PersistedState;
+    /**
+     * A function returning another (optional) function.
+     * The main function will be called before the state rehydration.
+     * The returned function will be called after the state rehydration or when an error occurred.
+     */
+    onRehydrateStorage?: (state: S) => ((state?: S, error?: unknown) => void) | void;
+    /**
+     * If the stored state's version mismatch the one specified here, the storage will not be used.
+     * This is useful when adding a breaking change to your store.
+     */
+    version?: number;
+    /**
+     * A function to perform persisted state migration.
+     * This function will be called when persisted state versions mismatch with the one specified here.
+     */
+    migrate?: (persistedState: unknown, version: number) => PersistedState | Promise<PersistedState>;
+    /**
+     * A function to perform custom hydration merges when combining the stored state with the current one.
+     * By default, this function does a shallow merge.
+     */
+    merge?: (persistedState: unknown, currentState: S) => S;
+    /**
+     * An optional boolean that will prevent the persist middleware from triggering hydration on initialization,
+     * This allows you to call `rehydrate()` at a specific point in your apps rendering life-cycle.
+     *
+     * This is useful in SSR application.
+     *
+     * @default false
+     */
+    skipHydration?: boolean;
+}
+type PersistListener<S> = (state: S) => void;
+type StorePersist<S, Ps> = {
+    persist: {
+        setOptions: (options: Partial<PersistOptions<S, Ps>>) => void;
+        clearStorage: () => void;
+        rehydrate: () => Promise<void> | void;
+        hasHydrated: () => boolean;
+        onHydrate: (fn: PersistListener<S>) => () => void;
+        onFinishHydration: (fn: PersistListener<S>) => () => void;
+        getOptions: () => Partial<PersistOptions<S, Ps>>;
+    };
+};
+type Persist = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = [], U = T>(initializer: StateCreator<T, [...Mps, ['zustand/persist', unknown]], Mcs>, options: PersistOptions<T, U>) => StateCreator<T, Mps, [['zustand/persist', U], ...Mcs]>;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        'zustand/persist': WithPersist<S, A>;
+    }
+}
+type Write<T, U> = Omit<T, keyof U> & U;
+type WithPersist<S, A> = S extends {
+    getState: () => infer T;
+} ? Write<S, StorePersist<T, A>> : never;
+export declare const persist: Persist;
+export {};

--- a/node_modules/zustand/middleware/redux.d.ts
+++ b/node_modules/zustand/middleware/redux.d.ts
@@ -1,0 +1,21 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type Write<T, U> = Omit<T, keyof U> & U;
+type Action = {
+    type: string;
+};
+type StoreRedux<A> = {
+    dispatch: (a: A) => A;
+    dispatchFromDevtools: true;
+};
+type ReduxState<A> = {
+    dispatch: StoreRedux<A>['dispatch'];
+};
+type WithRedux<S, A> = Write<S, StoreRedux<A>>;
+type Redux = <T, A extends Action, Cms extends [StoreMutatorIdentifier, unknown][] = []>(reducer: (state: T, action: A) => T, initialState: T) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        'zustand/redux': WithRedux<S, A>;
+    }
+}
+export declare const redux: Redux;
+export {};

--- a/node_modules/zustand/middleware/subscribeWithSelector.d.ts
+++ b/node_modules/zustand/middleware/subscribeWithSelector.d.ts
@@ -1,0 +1,25 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand/vanilla';
+type SubscribeWithSelector = <T, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [
+    ...Mps,
+    ['zustand/subscribeWithSelector', never]
+], Mcs>) => StateCreator<T, Mps, [['zustand/subscribeWithSelector', never], ...Mcs]>;
+type Write<T, U> = Omit<T, keyof U> & U;
+type WithSelectorSubscribe<S> = S extends {
+    getState: () => infer T;
+} ? Write<S, StoreSubscribeWithSelector<T>> : never;
+declare module '../vanilla' {
+    interface StoreMutators<S, A> {
+        ['zustand/subscribeWithSelector']: WithSelectorSubscribe<S>;
+    }
+}
+type StoreSubscribeWithSelector<T> = {
+    subscribe: {
+        (listener: (selectedState: T, previousSelectedState: T) => void): () => void;
+        <U>(selector: (state: T) => U, listener: (selectedState: U, previousSelectedState: U) => void, options?: {
+            equalityFn?: (a: U, b: U) => boolean;
+            fireImmediately?: boolean;
+        }): () => void;
+    };
+};
+export declare const subscribeWithSelector: SubscribeWithSelector;
+export {};

--- a/node_modules/zustand/package.json
+++ b/node_modules/zustand/package.json
@@ -1,0 +1,100 @@
+{
+  "name": "zustand",
+  "description": "🐻 Bear necessities for state management in React",
+  "private": false,
+  "type": "commonjs",
+  "version": "5.0.3",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "typesVersions": {
+    ">=4.5": {
+      "esm/*": [
+        "esm/*"
+      ],
+      "*": [
+        "*"
+      ]
+    },
+    "*": {
+      "esm/*": [
+        "ts_version_4.5_and_above_is_required.d.ts"
+      ],
+      "*": [
+        "ts_version_4.5_and_above_is_required.d.ts"
+      ]
+    }
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./esm/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "default": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
+    },
+    "./*": {
+      "import": {
+        "types": "./esm/*.d.mts",
+        "default": "./esm/*.mjs"
+      },
+      "default": {
+        "types": "./*.d.ts",
+        "default": "./*.js"
+      }
+    }
+  },
+  "files": [
+    "**"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=12.20.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/zustand.git"
+  },
+  "keywords": [
+    "react",
+    "state",
+    "manager",
+    "management",
+    "redux",
+    "store"
+  ],
+  "author": "Paul Henschel",
+  "contributors": [
+    "Jeremy Holcomb (https://github.com/JeremyRH)",
+    "Daishi Kato (https://github.com/dai-shi)"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pmndrs/zustand/issues"
+  },
+  "homepage": "https://github.com/pmndrs/zustand",
+  "packageManager": "pnpm@8.15.0",
+  "peerDependencies": {
+    "@types/react": ">=18.0.0",
+    "immer": ">=9.0.6",
+    "react": ">=18.0.0",
+    "use-sync-external-store": ">=1.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "immer": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "use-sync-external-store": {
+      "optional": true
+    }
+  }
+}

--- a/node_modules/zustand/react.d.ts
+++ b/node_modules/zustand/react.d.ts
@@ -1,0 +1,14 @@
+import type { ExtractState, Mutate, StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 'subscribe'>;
+export declare function useStore<S extends ReadonlyStoreApi<unknown>>(api: S): ExtractState<S>;
+export declare function useStore<S extends ReadonlyStoreApi<unknown>, U>(api: S, selector: (state: ExtractState<S>) => U): U;
+export type UseBoundStore<S extends ReadonlyStoreApi<unknown>> = {
+    (): ExtractState<S>;
+    <U>(selector: (state: ExtractState<S>) => U): U;
+} & S;
+type Create = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>): UseBoundStore<Mutate<StoreApi<T>, Mos>>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>) => UseBoundStore<Mutate<StoreApi<T>, Mos>>;
+};
+export declare const create: Create;
+export {};

--- a/node_modules/zustand/react.js
+++ b/node_modules/zustand/react.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var React = require('react');
+var vanilla = require('zustand/vanilla');
+
+const identity = (arg) => arg;
+function useStore(api, selector = identity) {
+  const slice = React.useSyncExternalStore(
+    api.subscribe,
+    () => selector(api.getState()),
+    () => selector(api.getInitialState())
+  );
+  React.useDebugValue(slice);
+  return slice;
+}
+const createImpl = (createState) => {
+  const api = vanilla.createStore(createState);
+  const useBoundStore = (selector) => useStore(api, selector);
+  Object.assign(useBoundStore, api);
+  return useBoundStore;
+};
+const create = (createState) => createState ? createImpl(createState) : createImpl;
+
+exports.create = create;
+exports.useStore = useStore;

--- a/node_modules/zustand/react/shallow.d.ts
+++ b/node_modules/zustand/react/shallow.d.ts
@@ -1,0 +1,1 @@
+export declare function useShallow<S, U>(selector: (state: S) => U): (state: S) => U;

--- a/node_modules/zustand/react/shallow.js
+++ b/node_modules/zustand/react/shallow.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var React = require('react');
+var shallow = require('zustand/vanilla/shallow');
+
+function useShallow(selector) {
+  const prev = React.useRef(undefined);
+  return (state) => {
+    const next = selector(state);
+    return shallow.shallow(prev.current, next) ? prev.current : prev.current = next;
+  };
+}
+
+exports.useShallow = useShallow;

--- a/node_modules/zustand/readme.md
+++ b/node_modules/zustand/readme.md
@@ -1,0 +1,508 @@
+<p align="center">
+  <img src="docs/bear.jpg" />
+</p>
+
+[![Build Status](https://img.shields.io/github/actions/workflow/status/pmndrs/zustand/lint-and-type.yml?branch=main&style=flat&colorA=000000&colorB=000000)](https://github.com/pmndrs/zustand/actions?query=workflow%3ALint)
+[![Build Size](https://img.shields.io/bundlephobia/minzip/zustand?label=bundle%20size&style=flat&colorA=000000&colorB=000000)](https://bundlephobia.com/result?p=zustand)
+[![Version](https://img.shields.io/npm/v/zustand?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/zustand)
+[![Downloads](https://img.shields.io/npm/dt/zustand.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/zustand)
+[![Discord Shield](https://img.shields.io/discord/740090768164651008?style=flat&colorA=000000&colorB=000000&label=discord&logo=discord&logoColor=ffffff)](https://discord.gg/poimandres)
+
+A small, fast and scalable bearbones state-management solution using simplified flux principles. Has a comfy API based on hooks, isn't boilerplatey or opinionated.
+
+Don't disregard it because it's cute. It has quite the claws, lots of time was spent dealing with common pitfalls, like the dreaded [zombie child problem](https://react-redux.js.org/api/hooks#stale-props-and-zombie-children), [react concurrency](https://github.com/bvaughn/rfcs/blob/useMutableSource/text/0000-use-mutable-source.md), and [context loss](https://github.com/facebook/react/issues/13332) between mixed renderers. It may be the one state-manager in the React space that gets all of these right.
+
+You can try a live demo [here](https://githubbox.com/pmndrs/zustand/tree/main/examples/demo).
+
+```bash
+npm install zustand
+```
+
+:warning: This readme is written for JavaScript users. If you are a TypeScript user, be sure to check out our [TypeScript Usage section](#typescript-usage).
+
+## First create a store
+
+Your store is a hook! You can put anything in it: primitives, objects, functions. State has to be updated immutably and the `set` function [merges state](./docs/guides/immutable-state-and-merging.md) to help it.
+
+```jsx
+import { create } from 'zustand'
+
+const useBearStore = create((set) => ({
+  bears: 0,
+  increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
+  removeAllBears: () => set({ bears: 0 }),
+}))
+```
+
+## Then bind your components, and that's it!
+
+Use the hook anywhere, no providers are needed. Select your state and the component will re-render on changes.
+
+```jsx
+function BearCounter() {
+  const bears = useBearStore((state) => state.bears)
+  return <h1>{bears} around here ...</h1>
+}
+
+function Controls() {
+  const increasePopulation = useBearStore((state) => state.increasePopulation)
+  return <button onClick={increasePopulation}>one up</button>
+}
+```
+
+### Why zustand over redux?
+
+- Simple and un-opinionated
+- Makes hooks the primary means of consuming state
+- Doesn't wrap your app in context providers
+- [Can inform components transiently (without causing render)](#transient-updates-for-often-occurring-state-changes)
+
+### Why zustand over context?
+
+- Less boilerplate
+- Renders components only on changes
+- Centralized, action-based state management
+
+---
+
+# Recipes
+
+## Fetching everything
+
+You can, but bear in mind that it will cause the component to update on every state change!
+
+```jsx
+const state = useBearStore()
+```
+
+## Selecting multiple state slices
+
+It detects changes with strict-equality (old === new) by default, this is efficient for atomic state picks.
+
+```jsx
+const nuts = useBearStore((state) => state.nuts)
+const honey = useBearStore((state) => state.honey)
+```
+
+If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can use [useShallow](./docs/guides/prevent-rerenders-with-use-shallow.md) to prevent unnecessary rerenders when the selector output does not change according to shallow equal.
+
+```jsx
+import { create } from 'zustand'
+import { useShallow } from 'zustand/react/shallow'
+
+const useBearStore = create((set) => ({
+  nuts: 0,
+  honey: 0,
+  treats: {},
+  // ...
+}))
+
+// Object pick, re-renders the component when either state.nuts or state.honey change
+const { nuts, honey } = useBearStore(
+  useShallow((state) => ({ nuts: state.nuts, honey: state.honey })),
+)
+
+// Array pick, re-renders the component when either state.nuts or state.honey change
+const [nuts, honey] = useBearStore(
+  useShallow((state) => [state.nuts, state.honey]),
+)
+
+// Mapped picks, re-renders the component when state.treats changes in order, count or keys
+const treats = useBearStore(useShallow((state) => Object.keys(state.treats)))
+```
+
+For more control over re-rendering, you may provide any custom equality function (this example requires the use of [`createWithEqualityFn`](./docs/migrations/migrating-to-v5.md#using-custom-equality-functions-such-as-shallow)).
+
+```jsx
+const treats = useBearStore(
+  (state) => state.treats,
+  (oldTreats, newTreats) => compare(oldTreats, newTreats),
+)
+```
+
+## Overwriting state
+
+The `set` function has a second argument, `false` by default. Instead of merging, it will replace the state model. Be careful not to wipe out parts you rely on, like actions.
+
+```jsx
+import omit from 'lodash-es/omit'
+
+const useFishStore = create((set) => ({
+  salmon: 1,
+  tuna: 2,
+  deleteEverything: () => set({}, true), // clears the entire store, actions included
+  deleteTuna: () => set((state) => omit(state, ['tuna']), true),
+}))
+```
+
+## Async actions
+
+Just call `set` when you're ready, zustand doesn't care if your actions are async or not.
+
+```jsx
+const useFishStore = create((set) => ({
+  fishies: {},
+  fetch: async (pond) => {
+    const response = await fetch(pond)
+    set({ fishies: await response.json() })
+  },
+}))
+```
+
+## Read from state in actions
+
+`set` allows fn-updates `set(state => result)`, but you still have access to state outside of it through `get`.
+
+```jsx
+const useSoundStore = create((set, get) => ({
+  sound: 'grunt',
+  action: () => {
+    const sound = get().sound
+    ...
+```
+
+## Reading/writing state and reacting to changes outside of components
+
+Sometimes you need to access state in a non-reactive way or act upon the store. For these cases, the resulting hook has utility functions attached to its prototype.
+
+:warning: This technique is not recommended for adding state in [React Server Components](https://github.com/reactjs/rfcs/blob/main/text/0188-server-components.md) (typically in Next.js 13 and above). It can lead to unexpected bugs and privacy issues for your users. For more details, see [#2200](https://github.com/pmndrs/zustand/discussions/2200).
+
+```jsx
+const useDogStore = create(() => ({ paw: true, snout: true, fur: true }))
+
+// Getting non-reactive fresh state
+const paw = useDogStore.getState().paw
+// Listening to all changes, fires synchronously on every change
+const unsub1 = useDogStore.subscribe(console.log)
+// Updating state, will trigger listeners
+useDogStore.setState({ paw: false })
+// Unsubscribe listeners
+unsub1()
+
+// You can of course use the hook as you always would
+function Component() {
+  const paw = useDogStore((state) => state.paw)
+  ...
+```
+
+### Using subscribe with selector
+
+If you need to subscribe with a selector,
+`subscribeWithSelector` middleware will help.
+
+With this middleware `subscribe` accepts an additional signature:
+
+```ts
+subscribe(selector, callback, options?: { equalityFn, fireImmediately }): Unsubscribe
+```
+
+```js
+import { subscribeWithSelector } from 'zustand/middleware'
+const useDogStore = create(
+  subscribeWithSelector(() => ({ paw: true, snout: true, fur: true })),
+)
+
+// Listening to selected changes, in this case when "paw" changes
+const unsub2 = useDogStore.subscribe((state) => state.paw, console.log)
+// Subscribe also exposes the previous value
+const unsub3 = useDogStore.subscribe(
+  (state) => state.paw,
+  (paw, previousPaw) => console.log(paw, previousPaw),
+)
+// Subscribe also supports an optional equality function
+const unsub4 = useDogStore.subscribe(
+  (state) => [state.paw, state.fur],
+  console.log,
+  { equalityFn: shallow },
+)
+// Subscribe and fire immediately
+const unsub5 = useDogStore.subscribe((state) => state.paw, console.log, {
+  fireImmediately: true,
+})
+```
+
+## Using zustand without React
+
+Zustand core can be imported and used without the React dependency. The only difference is that the create function does not return a hook, but the API utilities.
+
+```jsx
+import { createStore } from 'zustand/vanilla'
+
+const store = createStore((set) => ...)
+const { getState, setState, subscribe, getInitialState } = store
+
+export default store
+```
+
+You can use a vanilla store with `useStore` hook available since v4.
+
+```jsx
+import { useStore } from 'zustand'
+import { vanillaStore } from './vanillaStore'
+
+const useBoundStore = (selector) => useStore(vanillaStore, selector)
+```
+
+:warning: Note that middlewares that modify `set` or `get` are not applied to `getState` and `setState`.
+
+## Transient updates (for often occurring state-changes)
+
+The subscribe function allows components to bind to a state-portion without forcing re-render on changes. Best combine it with useEffect for automatic unsubscribe on unmount. This can make a [drastic](https://codesandbox.io/s/peaceful-johnson-txtws) performance impact when you are allowed to mutate the view directly.
+
+```jsx
+const useScratchStore = create((set) => ({ scratches: 0, ... }))
+
+const Component = () => {
+  // Fetch initial state
+  const scratchRef = useRef(useScratchStore.getState().scratches)
+  // Connect to the store on mount, disconnect on unmount, catch state-changes in a reference
+  useEffect(() => useScratchStore.subscribe(
+    state => (scratchRef.current = state.scratches)
+  ), [])
+  ...
+```
+
+## Sick of reducers and changing nested states? Use Immer!
+
+Reducing nested structures is tiresome. Have you tried [immer](https://github.com/mweststrate/immer)?
+
+```jsx
+import { produce } from 'immer'
+
+const useLushStore = create((set) => ({
+  lush: { forest: { contains: { a: 'bear' } } },
+  clearForest: () =>
+    set(
+      produce((state) => {
+        state.lush.forest.contains = null
+      }),
+    ),
+}))
+
+const clearForest = useLushStore((state) => state.clearForest)
+clearForest()
+```
+
+[Alternatively, there are some other solutions.](./docs/guides/updating-state.md#with-immer)
+
+## Persist middleware
+
+You can persist your store's data using any kind of storage.
+
+```jsx
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+const useFishStore = create(
+  persist(
+    (set, get) => ({
+      fishes: 0,
+      addAFish: () => set({ fishes: get().fishes + 1 }),
+    }),
+    {
+      name: 'food-storage', // name of the item in the storage (must be unique)
+      storage: createJSONStorage(() => sessionStorage), // (optional) by default, 'localStorage' is used
+    },
+  ),
+)
+```
+
+[See the full documentation for this middleware.](./docs/integrations/persisting-store-data.md)
+
+## Immer middleware
+
+Immer is available as middleware too.
+
+```jsx
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+
+const useBeeStore = create(
+  immer((set) => ({
+    bees: 0,
+    addBees: (by) =>
+      set((state) => {
+        state.bees += by
+      }),
+  })),
+)
+```
+
+## Can't live without redux-like reducers and action types?
+
+```jsx
+const types = { increase: 'INCREASE', decrease: 'DECREASE' }
+
+const reducer = (state, { type, by = 1 }) => {
+  switch (type) {
+    case types.increase:
+      return { grumpiness: state.grumpiness + by }
+    case types.decrease:
+      return { grumpiness: state.grumpiness - by }
+  }
+}
+
+const useGrumpyStore = create((set) => ({
+  grumpiness: 0,
+  dispatch: (args) => set((state) => reducer(state, args)),
+}))
+
+const dispatch = useGrumpyStore((state) => state.dispatch)
+dispatch({ type: types.increase, by: 2 })
+```
+
+Or, just use our redux-middleware. It wires up your main-reducer, sets the initial state, and adds a dispatch function to the state itself and the vanilla API.
+
+```jsx
+import { redux } from 'zustand/middleware'
+
+const useGrumpyStore = create(redux(reducer, initialState))
+```
+
+## Redux devtools
+
+Install the [Redux DevTools Chrome extension](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) to use the devtools middleware.
+
+```jsx
+import { devtools } from 'zustand/middleware'
+
+// Usage with a plain action store, it will log actions as "setState"
+const usePlainStore = create(devtools((set) => ...))
+// Usage with a redux store, it will log full action types
+const useReduxStore = create(devtools(redux(reducer, initialState)))
+```
+
+One redux devtools connection for multiple stores
+
+```jsx
+import { devtools } from 'zustand/middleware'
+
+// Usage with a plain action store, it will log actions as "setState"
+const usePlainStore1 = create(devtools((set) => ..., { name, store: storeName1 }))
+const usePlainStore2 = create(devtools((set) => ..., { name, store: storeName2 }))
+// Usage with a redux store, it will log full action types
+const useReduxStore = create(devtools(redux(reducer, initialState)), , { name, store: storeName3 })
+const useReduxStore = create(devtools(redux(reducer, initialState)), , { name, store: storeName4 })
+```
+
+Assigning different connection names will separate stores in redux devtools. This also helps group different stores into separate redux devtools connections.
+
+devtools takes the store function as its first argument, optionally you can name the store or configure [serialize](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize) options with a second argument.
+
+Name store: `devtools(..., {name: "MyStore"})`, which will create a separate instance named "MyStore" in the devtools.
+
+Serialize options: `devtools(..., { serialize: { options: true } })`.
+
+#### Logging Actions
+
+devtools will only log actions from each separated store unlike in a typical _combined reducers_ redux store. See an approach to combining stores https://github.com/pmndrs/zustand/issues/163
+
+You can log a specific action type for each `set` function by passing a third parameter:
+
+```jsx
+const useBearStore = create(devtools((set) => ({
+  ...
+  eatFish: () => set(
+    (prev) => ({ fishes: prev.fishes > 1 ? prev.fishes - 1 : 0 }),
+    undefined,
+    'bear/eatFish'
+  ),
+  ...
+```
+
+You can also log the action's type along with its payload:
+
+```jsx
+  ...
+  addFishes: (count) => set(
+    (prev) => ({ fishes: prev.fishes + count }),
+    undefined,
+    { type: 'bear/addFishes', count, }
+  ),
+  ...
+```
+
+If an action type is not provided, it is defaulted to "anonymous". You can customize this default value by providing an `anonymousActionType` parameter:
+
+```jsx
+devtools(..., { anonymousActionType: 'unknown', ... })
+```
+
+If you wish to disable devtools (on production for instance). You can customize this setting by providing the `enabled` parameter:
+
+```jsx
+devtools(..., { enabled: false, ... })
+```
+
+## React context
+
+The store created with `create` doesn't require context providers. In some cases, you may want to use contexts for dependency injection or if you want to initialize your store with props from a component. Because the normal store is a hook, passing it as a normal context value may violate the rules of hooks.
+
+The recommended method available since v4 is to use the vanilla store.
+
+```jsx
+import { createContext, useContext } from 'react'
+import { createStore, useStore } from 'zustand'
+
+const store = createStore(...) // vanilla store without hooks
+
+const StoreContext = createContext()
+
+const App = () => (
+  <StoreContext.Provider value={store}>
+    ...
+  </StoreContext.Provider>
+)
+
+const Component = () => {
+  const store = useContext(StoreContext)
+  const slice = useStore(store, selector)
+  ...
+```
+
+## TypeScript Usage
+
+Basic typescript usage doesn't require anything special except for writing `create<State>()(...)` instead of `create(...)`...
+
+```ts
+import { create } from 'zustand'
+import { devtools, persist } from 'zustand/middleware'
+import type {} from '@redux-devtools/extension' // required for devtools typing
+
+interface BearState {
+  bears: number
+  increase: (by: number) => void
+}
+
+const useBearStore = create<BearState>()(
+  devtools(
+    persist(
+      (set) => ({
+        bears: 0,
+        increase: (by) => set((state) => ({ bears: state.bears + by })),
+      }),
+      {
+        name: 'bear-storage',
+      },
+    ),
+  ),
+)
+```
+
+A more complete TypeScript guide is [here](docs/guides/typescript.md).
+
+## Best practices
+
+- You may wonder how to organize your code for better maintenance: [Splitting the store into separate slices](./docs/guides/slices-pattern.md).
+- Recommended usage for this unopinionated library: [Flux inspired practice](./docs/guides/flux-inspired-practice.md).
+- [Calling actions outside a React event handler in pre-React 18](./docs/guides/event-handler-in-pre-react-18.md).
+- [Testing](./docs/guides/testing.md)
+- For more, have a look [in the docs folder](./docs/)
+
+## Third-Party Libraries
+
+Some users may want to extend Zustand's feature set which can be done using third-party libraries made by the community. For information regarding third-party libraries with Zustand, visit [the doc](./docs/integrations/third-party-libraries.md).
+
+## Comparison with other libraries
+
+- [Difference between zustand and other state management libraries for React](https://docs.pmnd.rs/zustand/getting-started/comparison)

--- a/node_modules/zustand/shallow.d.ts
+++ b/node_modules/zustand/shallow.d.ts
@@ -1,0 +1,2 @@
+export { shallow } from 'zustand/vanilla/shallow';
+export { useShallow } from 'zustand/react/shallow';

--- a/node_modules/zustand/shallow.js
+++ b/node_modules/zustand/shallow.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var shallow = require('zustand/vanilla/shallow');
+var shallow$1 = require('zustand/react/shallow');
+
+
+
+Object.defineProperty(exports, "shallow", {
+	enumerable: true,
+	get: function () { return shallow.shallow; }
+});
+Object.defineProperty(exports, "useShallow", {
+	enumerable: true,
+	get: function () { return shallow$1.useShallow; }
+});

--- a/node_modules/zustand/traditional.d.ts
+++ b/node_modules/zustand/traditional.d.ts
@@ -1,0 +1,17 @@
+import type { Mutate, StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand/vanilla';
+type ExtractState<S> = S extends {
+    getState: () => infer T;
+} ? T : never;
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'getInitialState' | 'subscribe'>;
+export declare function useStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>>(api: S): ExtractState<S>;
+export declare function useStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>, U>(api: S, selector: (state: ExtractState<S>) => U, equalityFn?: (a: U, b: U) => boolean): U;
+export type UseBoundStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>> = {
+    (): ExtractState<S>;
+    <U>(selector: (state: ExtractState<S>) => U, equalityFn?: (a: U, b: U) => boolean): U;
+} & S;
+type CreateWithEqualityFn = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>, defaultEqualityFn?: <U>(a: U, b: U) => boolean): UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>, defaultEqualityFn?: <U>(a: U, b: U) => boolean) => UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>;
+};
+export declare const createWithEqualityFn: CreateWithEqualityFn;
+export {};

--- a/node_modules/zustand/traditional.js
+++ b/node_modules/zustand/traditional.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var React = require('react');
+var useSyncExternalStoreExports = require('use-sync-external-store/shim/with-selector');
+var vanilla = require('zustand/vanilla');
+
+const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports;
+const identity = (arg) => arg;
+function useStoreWithEqualityFn(api, selector = identity, equalityFn) {
+  const slice = useSyncExternalStoreWithSelector(
+    api.subscribe,
+    api.getState,
+    api.getInitialState,
+    selector,
+    equalityFn
+  );
+  React.useDebugValue(slice);
+  return slice;
+}
+const createWithEqualityFnImpl = (createState, defaultEqualityFn) => {
+  const api = vanilla.createStore(createState);
+  const useBoundStoreWithEqualityFn = (selector, equalityFn = defaultEqualityFn) => useStoreWithEqualityFn(api, selector, equalityFn);
+  Object.assign(useBoundStoreWithEqualityFn, api);
+  return useBoundStoreWithEqualityFn;
+};
+const createWithEqualityFn = (createState, defaultEqualityFn) => createState ? createWithEqualityFnImpl(createState, defaultEqualityFn) : createWithEqualityFnImpl;
+
+exports.createWithEqualityFn = createWithEqualityFn;
+exports.useStoreWithEqualityFn = useStoreWithEqualityFn;

--- a/node_modules/zustand/vanilla.d.ts
+++ b/node_modules/zustand/vanilla.d.ts
@@ -1,0 +1,31 @@
+type SetStateInternal<T> = {
+    _(partial: T | Partial<T> | {
+        _(state: T): T | Partial<T>;
+    }['_'], replace?: false): void;
+    _(state: T | {
+        _(state: T): T;
+    }['_'], replace: true): void;
+}['_'];
+export interface StoreApi<T> {
+    setState: SetStateInternal<T>;
+    getState: () => T;
+    getInitialState: () => T;
+    subscribe: (listener: (state: T, prevState: T) => void) => () => void;
+}
+export type ExtractState<S> = S extends {
+    getState: () => infer T;
+} ? T : never;
+type Get<T, K, F> = K extends keyof T ? T[K] : F;
+export type Mutate<S, Ms> = number extends Ms['length' & keyof Ms] ? S : Ms extends [] ? S : Ms extends [[infer Mi, infer Ma], ...infer Mrs] ? Mutate<StoreMutators<S, Ma>[Mi & StoreMutatorIdentifier], Mrs> : never;
+export type StateCreator<T, Mis extends [StoreMutatorIdentifier, unknown][] = [], Mos extends [StoreMutatorIdentifier, unknown][] = [], U = T> = ((setState: Get<Mutate<StoreApi<T>, Mis>, 'setState', never>, getState: Get<Mutate<StoreApi<T>, Mis>, 'getState', never>, store: Mutate<StoreApi<T>, Mis>) => U) & {
+    $$storeMutators?: Mos;
+};
+export interface StoreMutators<S, A> {
+}
+export type StoreMutatorIdentifier = keyof StoreMutators<unknown, unknown>;
+type CreateStore = {
+    <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>): Mutate<StoreApi<T>, Mos>;
+    <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(initializer: StateCreator<T, [], Mos>) => Mutate<StoreApi<T>, Mos>;
+};
+export declare const createStore: CreateStore;
+export {};

--- a/node_modules/zustand/vanilla.js
+++ b/node_modules/zustand/vanilla.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const createStoreImpl = (createState) => {
+  let state;
+  const listeners = /* @__PURE__ */ new Set();
+  const setState = (partial, replace) => {
+    const nextState = typeof partial === "function" ? partial(state) : partial;
+    if (!Object.is(nextState, state)) {
+      const previousState = state;
+      state = (replace != null ? replace : typeof nextState !== "object" || nextState === null) ? nextState : Object.assign({}, state, nextState);
+      listeners.forEach((listener) => listener(state, previousState));
+    }
+  };
+  const getState = () => state;
+  const getInitialState = () => initialState;
+  const subscribe = (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+  const api = { setState, getState, getInitialState, subscribe };
+  const initialState = state = createState(setState, getState, api);
+  return api;
+};
+const createStore = (createState) => createState ? createStoreImpl(createState) : createStoreImpl;
+
+exports.createStore = createStore;

--- a/node_modules/zustand/vanilla/shallow.d.ts
+++ b/node_modules/zustand/vanilla/shallow.d.ts
@@ -1,0 +1,1 @@
+export declare function shallow<T>(valueA: T, valueB: T): boolean;

--- a/node_modules/zustand/vanilla/shallow.js
+++ b/node_modules/zustand/vanilla/shallow.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const isIterable = (obj) => Symbol.iterator in obj;
+const hasIterableEntries = (value) => (
+  // HACK: avoid checking entries type
+  "entries" in value
+);
+const compareEntries = (valueA, valueB) => {
+  const mapA = valueA instanceof Map ? valueA : new Map(valueA.entries());
+  const mapB = valueB instanceof Map ? valueB : new Map(valueB.entries());
+  if (mapA.size !== mapB.size) {
+    return false;
+  }
+  for (const [key, value] of mapA) {
+    if (!Object.is(value, mapB.get(key))) {
+      return false;
+    }
+  }
+  return true;
+};
+const compareIterables = (valueA, valueB) => {
+  const iteratorA = valueA[Symbol.iterator]();
+  const iteratorB = valueB[Symbol.iterator]();
+  let nextA = iteratorA.next();
+  let nextB = iteratorB.next();
+  while (!nextA.done && !nextB.done) {
+    if (!Object.is(nextA.value, nextB.value)) {
+      return false;
+    }
+    nextA = iteratorA.next();
+    nextB = iteratorB.next();
+  }
+  return !!nextA.done && !!nextB.done;
+};
+function shallow(valueA, valueB) {
+  if (Object.is(valueA, valueB)) {
+    return true;
+  }
+  if (typeof valueA !== "object" || valueA === null || typeof valueB !== "object" || valueB === null) {
+    return false;
+  }
+  if (!isIterable(valueA) || !isIterable(valueB)) {
+    return compareEntries(
+      { entries: () => Object.entries(valueA) },
+      { entries: () => Object.entries(valueB) }
+    );
+  }
+  if (hasIterableEntries(valueA) && hasIterableEntries(valueB)) {
+    return compareEntries(valueA, valueB);
+  }
+  return compareIterables(valueA, valueB);
+}
+
+exports.shallow = shallow;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "ideal-study-mvp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "zustand": "^5.0.3"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "zustand": "^5.0.3"
+  }
+}


### PR DESCRIPTION
### 연관된 이슈

> ex) -

### 작업 내용

> Zustand 도입하며 불필요한 props drilling 들을 모두 제거했습니다.
> 작업하면서 생각한 것이 어쩌면 props drilling 으로 명시해야 좀 더 가독성 높아지는 경우가 있을듯합니다 (가령 부모 컴포넌트의 상태가 자식 어디에서 사용되는지 한눈에 확인할 필요가 있을 경우?) 즉 '어떤 것을 상태관리할지' 에 대한 것도 고려하면서 써야겠습니다.

### 리뷰 요구사항

> 노션 기술기록에 상태관리 관련 자료 아카이빙 중입니다.
